### PR TITLE
Move temperature calibration to app_config

### DIFF
--- a/backend/app_cfg.yaml
+++ b/backend/app_cfg.yaml
@@ -34,6 +34,20 @@ SafetyFunctions:
       # Recommended: true for production to avoid silently running with wrong IDs.
       validate_entity_existence: true
 
+    # Calibration defaults for safety components.
+    calibration:
+      temperature:
+        # Debounce counter threshold for sm_tc_1 before setting/clearing symptoms.
+        SM_TC_1_DEBOUNCE_LIMIT: 2
+        # Delay before re-evaluating sm_tc_1 when debouncing requires another run.
+        SM_TC_1_REEVAL_DELAY_SECONDS: 30
+        # Debounce counter threshold for sm_tc_2 before setting/clearing symptoms.
+        SM_TC_2_DEBOUNCE_LIMIT: 2
+        # Delay before re-evaluating sm_tc_2 when debouncing requires another run.
+        SM_TC_2_REEVAL_DELAY_SECONDS: 30
+        # Sampling interval (minutes) used to register derivative monitoring for sm_tc_2.
+        SM_TC_2_DERIVATIVE_SAMPLE_MINUTES: 15
+
     # Global fault catalog (shared policy).
     #
     # IMPORTANT:

--- a/backend/components/app_config_validator/app_cfg_validator.py
+++ b/backend/components/app_config_validator/app_cfg_validator.py
@@ -113,7 +113,10 @@ def _to_runtime(
     for name, component_cfg in enabled_components.items():
         if name == TEMPERATURE_COMPONENT_NAME:
             runtime_components[name] = validate_temperature_config(
-                component_cfg, strict_validation=strict_validation, log=log
+                component_cfg,
+                strict_validation=strict_validation,
+                log=log,
+                calibration=cfg.app_config.calibration.temperature.model_dump(),
             )
         else:
             runtime_components[name] = component_cfg
@@ -169,6 +172,12 @@ class AppCfgValidator:
             log_extra_keys(cfg, log, "root")
             log_extra_keys(cfg.app_config, log, "app_config")
             log_extra_keys(cfg.app_config.validation, log, "app_config.validation")
+            log_extra_keys(cfg.app_config.calibration, log, "app_config.calibration")
+            log_extra_keys(
+                cfg.app_config.calibration.temperature,
+                log,
+                "app_config.calibration.temperature",
+            )
             log_extra_keys(cfg.user_config, log, "user_config")
 
         entity_ids = _collect_entity_ids(runtime_cfg)

--- a/backend/components/app_config_validator/schema.py
+++ b/backend/components/app_config_validator/schema.py
@@ -18,6 +18,26 @@ class ValidationSettings(StrictBaseModel):
     validate_entity_existence: bool = True
 
 
+class TemperatureCalibration(StrictBaseModel):
+    """Calibration defaults for the temperature component."""
+
+    model_config = ConfigDict(extra="allow")
+
+    SM_TC_1_DEBOUNCE_LIMIT: int = 2
+    SM_TC_1_REEVAL_DELAY_SECONDS: int = 30
+    SM_TC_2_DEBOUNCE_LIMIT: int = 2
+    SM_TC_2_REEVAL_DELAY_SECONDS: int = 30
+    SM_TC_2_DERIVATIVE_SAMPLE_MINUTES: int = 15
+
+
+class CalibrationSettings(StrictBaseModel):
+    """Calibration defaults for safety components."""
+
+    model_config = ConfigDict(extra="allow")
+
+    temperature: TemperatureCalibration = Field(default_factory=TemperatureCalibration)
+
+
 class AppPolicy(StrictBaseModel):
     """Application-wide configuration shared across installations."""
 
@@ -26,6 +46,7 @@ class AppPolicy(StrictBaseModel):
     config_version: int = Field(..., ge=1)
     strict_validation: bool = True
     validation: ValidationSettings = Field(default_factory=ValidationSettings)
+    calibration: CalibrationSettings = Field(default_factory=CalibrationSettings)
     faults: Dict[str, Dict[str, Any]]
 
 


### PR DESCRIPTION
What changed

Moved temperature calibration knobs to app_config.calibration.temperature and wired them through validation.
Added calibration defaults and merged them into the temperature runtime config.
Updated safety mechanism scheduling/derivative sampling to use the calibration values.
Documented each calibration key inline in app_cfg.yaml.

Why
Calibration is global policy, not per-user config; improves clarity and keeps user configs focused on house specifics.

Tests
pytest backend/tests