### PR TITLE
Add event bus integration for safety flow

### DIFF
--- a/backend/components/core/event_bus.py
+++ b/backend/components/core/event_bus.py
@@ -1,0 +1,31 @@
+"""Simple synchronous event bus with deterministic ordering."""
+
+from __future__ import annotations
+
+from itertools import count
+from typing import Any, Callable, Dict, List, Tuple
+
+
+class EventBus:
+    """Publish/subscribe event bus with priority-based ordering."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, List[Tuple[int, int, Callable[..., None]]]] = {}
+        self._counter = count()
+
+    def subscribe(
+        self, event_type: str, handler: Callable[..., None], *, priority: int = 0
+    ) -> None:
+        """Register a handler for an event type with an optional priority."""
+        order = next(self._counter)
+        self._subscribers.setdefault(event_type, []).append((priority, order, handler))
+        self._subscribers[event_type].sort(key=lambda item: (item[0], item[1]))
+
+    def publish(self, event_type: str, **payload: Any) -> None:
+        """Publish an event to all subscribers synchronously."""
+        for _, __, handler in self._subscribers.get(event_type, []):
+            handler(**payload)
+
+    def clear(self) -> None:
+        """Remove all subscriptions (primarily for tests)."""
+        self._subscribers.clear()

--- a/backend/components/notification_manager/notification_manager.py
+++ b/backend/components/notification_manager/notification_manager.py
@@ -105,6 +105,22 @@ class NotificationManager:
         else:
             self.hass_app.log(f"Invalid fault status '{fault_status}'", level="WARNING")
 
+    def handle_fault_event(
+        self,
+        *,
+        fault_name: str,
+        level: int,
+        fault_state: FaultState,
+        additional_info: Optional[dict],
+        fault_tag: str,
+        should_notify: bool = True,
+        **_: object,
+    ) -> None:
+        """EventBus handler for fault events."""
+        if not should_notify:
+            return
+        self.notify(fault_name, level, fault_state, additional_info, fault_tag)
+
     def _process_active_fault(self, level: int, message: str, fault_tag: str) -> None:
         self._notify_company_app(level, message, fault_tag, FaultState.SET)
         additional_actions = self.level_methods.get(level)

--- a/backend/components/recovery_manager/recovery_manager.py
+++ b/backend/components/recovery_manager/recovery_manager.py
@@ -322,6 +322,12 @@ class RecoveryManager:
             f"Recovery process completed for symptom: {symptom.name}", level="DEBUG"
         )
 
+    def handle_fault_event(
+        self, *, symptom: Symptom, fault_tag: str, **_: object
+    ) -> None:
+        """EventBus handler for fault events."""
+        self.recovery(symptom, fault_tag)
+
     def _handle_cleared_state(self, symptom: Symptom) -> None:
         """Handles the cleared state of a symptom by clearing recovery actions."""
         self.hass_app.log(

--- a/backend/components/safetycomponents/temperature/temperature_component.py
+++ b/backend/components/safetycomponents/temperature/temperature_component.py
@@ -55,7 +55,12 @@ class TemperatureComponent(SafetyComponent):
     component_name: str = "TemperatureComponent"
 
     # region Init and enables
-    def __init__(self, hass_app: hass, common_entities: CommonEntities) -> None:  # type: ignore
+    def __init__(
+        self,
+        hass_app: hass,
+        common_entities: CommonEntities,
+        event_bus: Any,
+    ) -> None:  # type: ignore
         """
         Initializes the TemperatureComponent instance with the Home Assistant application context, setting up the foundation
         for temperature-related safety management within the smart home environment.
@@ -64,7 +69,7 @@ class TemperatureComponent(SafetyComponent):
             hass_app (hass.Hass): The Home Assistant application instance through which sensor data is accessed and actions are executed.
             common_entities (CommonEntities): A shared object providing access to common entities used across different safety mechanisms.
         """
-        super().__init__(hass_app, common_entities)
+        super().__init__(hass_app, common_entities, event_bus)
 
     def get_symptoms_data(
         self, sm_modules: dict, component_cfg: list[dict[str, Any]]

--- a/backend/tests/test_event_bus.py
+++ b/backend/tests/test_event_bus.py
@@ -1,0 +1,17 @@
+from components.core.event_bus import EventBus
+
+
+def test_event_bus_orders_by_priority_and_registration():
+    bus = EventBus()
+    calls = []
+
+    def handler(name, **_):
+        calls.append(name)
+
+    bus.subscribe("evt", lambda **kw: handler("second", **kw), priority=1)
+    bus.subscribe("evt", lambda **kw: handler("first", **kw), priority=0)
+    bus.subscribe("evt", lambda **kw: handler("third", **kw), priority=1)
+
+    bus.publish("evt", payload=True)
+
+    assert calls == ["first", "second", "third"]

--- a/backend/tests/test_initialization.py
+++ b/backend/tests/test_initialization.py
@@ -49,8 +49,9 @@ def test_fault_manager_initialization(mocked_hass_app_with_temp_component):
     app_instance.initialize()
 
     assert isinstance(app_instance.fm, FaultManager)
-    assert app_instance.fm.notify_interface == app_instance.notify_man.notify
-    assert app_instance.fm.recovery_interface == app_instance.reco_man.recovery
+    assert app_instance.fm.event_bus is app_instance.event_bus
+    assert "symptom" in app_instance.event_bus._subscribers
+    assert "fault" in app_instance.event_bus._subscribers
     assert (
         app_instance.fm.sm_modules["TemperatureComponent"]
         == app_instance.sm_modules["TemperatureComponent"]
@@ -62,7 +63,7 @@ def test_assign_fm(mocked_hass_app_with_temp_component):
     app_instance.initialize()
 
     for module in app_instance.sm_modules.values():
-        assert module.fault_man is app_instance.fm
+        assert module.event_bus is app_instance.event_bus
 
 
 def test_app_health_set_to_good_at_end_of_init(mocked_hass_app_with_temp_component):

--- a/backend/tests/test_safetyFunctions.py
+++ b/backend/tests/test_safetyFunctions.py
@@ -102,8 +102,6 @@ def test_recovery_process_execution(mocked_hass_app_with_temp_component):
 
     # Mock the recovery action to track if it's called
     app_instance.reco_man.recovery = Mock()
-    # Bind new Mock with recovery_interface
-    app_instance.fm.recovery_interface = app_instance.reco_man.recovery
 
     # Manually trigger a symptom
     app_instance.fm.set_symptom("RiskyTemperatureOffice", None)


### PR DESCRIPTION
What changed

Introduced EventBus with deterministic priority ordering.
Safety components emit symptom events instead of calling FaultManager directly.
FaultManager consumes symptom events, applies policy, and publishes fault events.
Notification and Recovery managers subscribe to fault events with ordered handling.
Updated tests to match the event-driven integration and added a bus ordering test.
Why

Decouples mechanism detection from policy and side effects.
Ensures strict, synchronous ordering for safety-critical behavior.
Simplifies mocking and testing by substituting event handlers.
Tests

pytest backend/tests