### PR TITLE
Add overtemperature safety mechanisms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,13 @@ This file provides guidance and memory for Codex CLI.
 - Use a Python 3.10+ virtual environment with pytest installed; the test suite uses the bundled AppDaemon Hass stub under `backend/tests/appdaemon` to avoid external dependencies.
 - The most recent verification ran `pytest backend/tests` successfully.
 
+## Backend Coding Standards
+- Use type hints for function signatures, class attributes, and complex variables whenever practical.
+- Follow PEP 8 naming conventions (`snake_case` for functions/variables, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants).
+- Add docstrings to all public modules, classes, and functions describing purpose, inputs, and outputs.
+- Group imports into standard library, third-party, and local blocks, keeping imports ordered within each group.
+- Prefer clear, explicit logic and meaningful names over terse constructs.
+
 <!-- BEGIN: BMAD-AGENTS -->
 # BMAD-METHOD Agents and Tasks
 
@@ -7302,4 +7309,3 @@ Based on the analysis and agreed path forward:
 ```
 
 <!-- END: BMAD-AGENTS -->
-

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+# Backend
+
+## Coding Standards
+
+Follow these conventions when working on the backend codebase:
+
+- **Type hints**: Use type hints for function signatures, class attributes, and complex variables whenever practical.
+- **PEP 8 naming**: Use `snake_case` for functions/variables, `PascalCase` for classes, and `UPPER_SNAKE_CASE` for constants.
+- **Docstrings**: Add docstrings to all public modules, classes, and functions to describe purpose, inputs, and outputs.
+- **Imports**: Group standard library, third-party, and local imports separately, and keep imports ordered within each group.
+- **Clarity over cleverness**: Prefer explicit, readable logic and meaningful names over terse constructs.
+
+If you are unsure about an existing pattern, check nearby modules in `backend/` and follow the established style.

--- a/backend/app_cfg.yaml
+++ b/backend/app_cfg.yaml
@@ -65,11 +65,13 @@ SafetyFunctions:
         level: 2
         related_sms:
           - "sm_tc_1"
+          - "sm_tc_3"
       RiskyTemperatureForecast:
         name: "Unsafe temperature forecast"
         level: 3
         related_sms:
           - "sm_tc_2"
+          - "sm_tc_4"
 
   # ---------------------------------------------------------------------------
   # House/installation specific configuration (entities, thresholds, enablement).
@@ -130,6 +132,7 @@ SafetyFunctions:
         # Defaults shared across rooms, can be overridden per room.
         defaults:
           CAL_LOW_TEMP_THRESHOLD: 18.0
+          CAL_HIGH_TEMP_THRESHOLD: 28.0
           CAL_FORECAST_TIMESPAN: 2.0 # hours
 
         # Per-room configuration

--- a/backend/app_cfg.yaml
+++ b/backend/app_cfg.yaml
@@ -164,6 +164,7 @@ SafetyFunctions:
           Garage:
             # Override defaults for this room
             CAL_LOW_TEMP_THRESHOLD: 10.0
+            CAL_HIGH_TEMP_THRESHOLD: 28.0
             CAL_FORECAST_TIMESPAN: 2.0
             temperature_sensor: "sensor.garage_temperature"
             window_sensor: "binary_sensor.garage_gatedoorlow_contact_contact"

--- a/backend/components/faults_manager/fault_manager.py
+++ b/backend/components/faults_manager/fault_manager.py
@@ -406,7 +406,7 @@ class FaultManager:
         if fault and not any(
             symptom.state == FaultState.SET
             for symptom in self.symptoms.values()
-            if symptom.sm_name == sm_name
+            if symptom.sm_name in set(fault.related_symptoms)
         ):  # If Fault was found and if other fault related symptoms are not raised
             # Generate a unique fault tag using the hash method
             fault_tag: str = self._generate_fault_tag(fault.name, additional_info)

--- a/backend/tests/fixtures/test_sf_cfgs.py
+++ b/backend/tests/fixtures/test_sf_cfgs.py
@@ -6,12 +6,12 @@ def _base_faults():
         "RiskyTemperature": {
             "name": "Unsafe temperature",
             "level": 2,
-            "related_sms": ["sm_tc_1"],
+            "related_sms": ["sm_tc_1", "sm_tc_3"],
         },
         "RiskyTemperatureForecast": {
             "name": "Unsafe temperature forecast",
             "level": 3,
-            "related_sms": ["sm_tc_2"],
+            "related_sms": ["sm_tc_2", "sm_tc_4"],
         },
     }
 
@@ -20,12 +20,14 @@ def _temperature_component_rooms():
     return {
         "Office": {
             "CAL_LOW_TEMP_THRESHOLD": 18.0,
+            "CAL_HIGH_TEMP_THRESHOLD": 28.0,
             "CAL_FORECAST_TIMESPAN": 2.0,
             "temperature_sensor": "sensor.office_temperature",
             "window_sensor": "sensor.office_window_contact_contact",
         },
         "Kitchen": {
             "CAL_LOW_TEMP_THRESHOLD": 18.0,
+            "CAL_HIGH_TEMP_THRESHOLD": 28.0,
             "CAL_FORECAST_TIMESPAN": 2.0,
             "temperature_sensor": "sensor.kitchen_temperature",
             "window_sensor": "sensor.kitchen_window_contact_contact",
@@ -42,6 +44,7 @@ def _base_user_config():
             "TemperatureComponent": {
                 "defaults": {
                     "CAL_LOW_TEMP_THRESHOLD": 18.0,
+                    "CAL_HIGH_TEMP_THRESHOLD": 28.0,
                     "CAL_FORECAST_TIMESPAN": 2.0,
                 },
                 "rooms": _temperature_component_rooms(),

--- a/backend/tests/test_app_cfg_validator.py
+++ b/backend/tests/test_app_cfg_validator.py
@@ -48,8 +48,10 @@ def test_validate_app_cfg_uses_defaults_when_room_thresholds_missing(app_config_
     component_cfg = cfg["user_config"]["safety_components"]["TemperatureComponent"]
     defaults = component_cfg["defaults"]
     component_cfg["rooms"]["Office"].pop("CAL_LOW_TEMP_THRESHOLD")
+    component_cfg["rooms"]["Office"].pop("CAL_HIGH_TEMP_THRESHOLD")
     component_cfg["rooms"]["Office"].pop("CAL_FORECAST_TIMESPAN")
     component_cfg["rooms"]["Kitchen"].pop("CAL_LOW_TEMP_THRESHOLD")
+    component_cfg["rooms"]["Kitchen"].pop("CAL_HIGH_TEMP_THRESHOLD")
     component_cfg["rooms"]["Kitchen"].pop("CAL_FORECAST_TIMESPAN")
 
     validated = AppCfgValidator.validate(cfg)
@@ -59,8 +61,13 @@ def test_validate_app_cfg_uses_defaults_when_room_thresholds_missing(app_config_
     kitchen_cfg = next(room["Kitchen"] for room in temperature_cfg if "Kitchen" in room)
 
     assert office_cfg["CAL_LOW_TEMP_THRESHOLD"] == defaults["CAL_LOW_TEMP_THRESHOLD"]
+    assert office_cfg["CAL_HIGH_TEMP_THRESHOLD"] == defaults["CAL_HIGH_TEMP_THRESHOLD"]
     assert office_cfg["CAL_FORECAST_TIMESPAN"] == defaults["CAL_FORECAST_TIMESPAN"]
     assert kitchen_cfg["CAL_LOW_TEMP_THRESHOLD"] == defaults["CAL_LOW_TEMP_THRESHOLD"]
+    assert (
+        kitchen_cfg["CAL_HIGH_TEMP_THRESHOLD"]
+        == defaults["CAL_HIGH_TEMP_THRESHOLD"]
+    )
     assert kitchen_cfg["CAL_FORECAST_TIMESPAN"] == defaults["CAL_FORECAST_TIMESPAN"]
 
 

--- a/backend/tests/test_notify_man.py
+++ b/backend/tests/test_notify_man.py
@@ -62,17 +62,17 @@ def test_temp_comp_notification(
         mocked_hass_app_with_temp_component
     )
 
+    app_instance.initialize()
+
     test_mock_behaviours: List[MockBehavior[str, Iterator[str]]] = [
         MockBehavior("sensor.office_temperature", iter(temperature))
     ]
     mock_behaviors_default: List[MockBehavior] = update_mocked_get_state(
         mock_behaviors_default, test_mock_behaviours
     )
-
     app_instance.get_state.side_effect = lambda entity_id, **kwargs: mock_get_state(
         entity_id, mock_behaviors_default
     )
-    app_instance.initialize()
 
     for _ in range(test_size):
         app_instance.sm_modules["TemperatureComponent"].sm_tc_1(

--- a/backend/tests/test_notify_man.py
+++ b/backend/tests/test_notify_man.py
@@ -97,6 +97,85 @@ def test_temp_comp_notification(
         # Check last one
         assert notify_call[-1].kwargs["title"] == prefault_title
         assert notify_call[-1].kwargs["message"] == prefault_message
+
+
+def test_temp_comp_overtemp_notification(mocked_hass_app_with_temp_component):
+    """
+    Test Case: Verify overtemperature notification is sent.
+    """
+    app_instance, _, __, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+    app_instance.initialize()
+
+    test_mock_behaviours: List[MockBehavior[str, Iterator[str]]] = [
+        MockBehavior("sensor.office_temperature", iter(["30", "31", "32", "33", "34"]))
+    ]
+    mock_behaviors_default: List[MockBehavior] = update_mocked_get_state(
+        mock_behaviors_default, test_mock_behaviours
+    )
+    app_instance.get_state.side_effect = lambda entity_id, **kwargs: mock_get_state(
+        entity_id, mock_behaviors_default
+    )
+
+    for _ in range(5):
+        app_instance.sm_modules["TemperatureComponent"].sm_tc_3(
+            app_instance.sm_modules["TemperatureComponent"].safety_mechanisms[
+                "RiskyTemperatureHighOffice"
+            ]
+        )
+
+    notify_call = [
+        call
+        for call in app_instance.call_service.call_args_list
+        if "notify" in call.args[0]
+    ]
+    assert notify_call[-1].kwargs["title"] == "Hazard!"
+    assert (
+        notify_call[-1].kwargs["message"]
+        == "Fault: RiskyTemperature\nlocation: Office\n"
+    )
+
+
+def test_temp_comp_overtemp_forecast_notification(
+    mocked_hass_app_with_temp_component,
+):
+    """
+    Test Case: Verify overtemperature forecast notification is sent.
+    """
+    app_instance, _, __, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+    app_instance.initialize()
+
+    test_mock_behaviours: List[MockBehavior[str, Iterator[str]]] = [
+        MockBehavior("sensor.office_temperature", iter(["30", "30", "30", "30"])),
+        MockBehavior("sensor.office_temperature_rate", iter(["1", "1", "1", "1"])),
+    ]
+    mock_behaviors_default: List[MockBehavior] = update_mocked_get_state(
+        mock_behaviors_default, test_mock_behaviours
+    )
+    app_instance.get_state.side_effect = lambda entity_id, **kwargs: mock_get_state(
+        entity_id, mock_behaviors_default
+    )
+
+    for _ in range(5):
+        app_instance.sm_modules["TemperatureComponent"].sm_tc_4(
+            app_instance.sm_modules["TemperatureComponent"].safety_mechanisms[
+                "RiskyTemperatureHighOfficeForeCast"
+            ]
+        )
+
+    notify_call = [
+        call
+        for call in app_instance.call_service.call_args_list
+        if "notify" in call.args[0]
+    ]
+    assert notify_call[-1].kwargs["title"] == "Warning!"
+    assert (
+        notify_call[-1].kwargs["message"]
+        == "Fault: RiskyTemperatureForecast\nlocation: Office\n"
+    )
         
 def test_notify_fault_set(mocked_hass_app_with_temp_component):
     """

--- a/backend/tests/test_temperatureComponent.py
+++ b/backend/tests/test_temperatureComponent.py
@@ -73,6 +73,64 @@ def test_temp_comp_smtc1(
     assert app_instance.fm.check_fault("RiskyTemperature") == expected_fault_state
 
 
+@pytest.mark.parametrize(
+    "temperature, expected_symptom_state, expected_fault_state",
+    [
+        (
+            ["20", "21", "22", "23", "24"],
+            FaultState.CLEARED,
+            FaultState.CLEARED,
+        ),
+        (
+            ["30", "31", "32", "33", "34"],
+            FaultState.SET,
+            FaultState.SET,
+        ),
+    ],
+)
+def test_temp_comp_smtc3(
+    mocked_hass_app_with_temp_component,
+    temperature,
+    expected_symptom_state,
+    expected_fault_state,
+):
+    """
+    Test Case: Verify overtemperature symptom and fault states based on temperature input.
+
+    Scenario:
+        - Input: Temperature sequences with varying levels.
+        - Expected Result: Symptom and fault states should match expected values based on temperature.
+    """
+    app_instance, _, __, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+
+    test_mock_behaviours: List[MockBehavior[str, Iterator[str]]] = [
+        MockBehavior("sensor.office_temperature", iter(temperature))
+    ]
+    mock_behaviors_default: List[MockBehavior] = update_mocked_get_state(
+        mock_behaviors_default, test_mock_behaviours
+    )
+
+    app_instance.get_state.side_effect = lambda entity_id, **kwargs: mock_get_state(
+        entity_id, mock_behaviors_default
+    )
+    app_instance.initialize()
+
+    for _ in range(5):
+        app_instance.sm_modules["TemperatureComponent"].sm_tc_3(
+            app_instance.sm_modules["TemperatureComponent"].safety_mechanisms[
+                "RiskyTemperatureHighOffice"
+            ]
+        )
+
+    assert (
+        app_instance.fm.check_symptom("RiskyTemperatureHighOffice")
+        == expected_symptom_state
+    )
+    assert app_instance.fm.check_fault("RiskyTemperature") == expected_fault_state
+
+
 def test_symptom_set_when_temp_NOT_below_threshold(mocked_hass_app_with_temp_component):
     """
     Test Case: Symptom Set When Temperature is Below Threshold
@@ -243,6 +301,55 @@ def test_forecasted_symptom_set_when_temp_rate_indicates_drop(
     # Assert the symptom state
     assert (
         app_instance.fm.check_symptom("RiskyTemperatureOfficeForeCast")
+        is FaultState.SET
+    )
+
+
+def test_forecasted_overtemp_symptom_set_when_temp_rate_indicates_rise(
+    mocked_hass_app_with_temp_component,
+):
+    """
+    Test Case: Forecasted Overtemperature Symptom Set When Temperature Rate Indicates a Rise
+
+    Scenario:
+        - Input: Initial temperature is 30.0\u0abbC, rate is 1.0\u0abbC/min, and forecast timespan is 2 hours.
+        - Expected Result: Symptom "RiskyTemperatureHighOfficeForeCast" should be set to True.
+    """
+    app_instance, __, _, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+    temperature_sequence = ["30.0"]
+    rate_of_change = "1"
+
+    # Initialize the application and register the monitored entity in DerivativeMonitor
+    app_instance.initialize()
+    app_instance.derivative_monitor.register_entity(
+        "sensor.office_temperature",
+        sample_time=60*15,  # Sampling every 1 minute
+        low_saturation=-10.0,
+        high_saturation=10.0,
+    )
+
+    # Mock the states for temperature and rate
+    app_instance.get_state.side_effect = lambda entity_id, **kwargs: mock_get_state(
+        entity_id,
+        [
+            MockBehavior("sensor.office_temperature", iter(temperature_sequence)),
+            MockBehavior("sensor.office_temperature_rate", iter([rate_of_change])),
+        ],
+    )
+
+    # Simulate multiple iterations to reach the debounce limit
+    for _ in range(DEBOUNCE_LIMIT + 2):
+        app_instance.sm_modules["TemperatureComponent"].sm_tc_4(
+            app_instance.sm_modules["TemperatureComponent"].safety_mechanisms[
+                "RiskyTemperatureHighOfficeForeCast"
+            ]
+        )
+
+    # Assert the symptom state
+    assert (
+        app_instance.fm.check_symptom("RiskyTemperatureHighOfficeForeCast")
         is FaultState.SET
     )
 


### PR DESCRIPTION
## Summary
- add overtemperature safety mechanisms (threshold + forecast) while keeping existing faults
- add high temperature thresholds to temperature config schema/defaults and sample config
- ensure faults only clear once all related SMs clear
- add tests for overtemperature behavior and notifications

## Testing
- pytest backend/tests