### PR TITLE
Migrate SafetyFunctions entities to MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository is dedicated to developing a Safety Component for the Home Assis
 - AppDaemon app (`SafetyFunctions`) that manages safety mechanisms, faults, notifications, and recovery flows.
 - Component framework for domain-specific safety logic (e.g., temperature monitoring).
 - Configuration schema validation with strict mode and runtime entity checks.
+- MQTT discovery, state, attributes, availability, and heartbeat for internal SafetyFunctions entities.
 - In-repo system documentation for safety concept and system requirements.
 
 ## Documentation
@@ -24,14 +25,16 @@ This repository is dedicated to developing a Safety Component for the Home Assis
 ## Usage
 1. Copy or merge `backend/app_cfg.yaml` into your AppDaemon `apps.yaml` (or set it as your AppDaemon config file).
 2. Update entity IDs and room configuration under `user_config`.
-3. Start AppDaemon and verify the health entity `sensor.safety_app_health` transitions to `running`.
+3. Start AppDaemon and verify Home Assistant discovers `sensor.safety_app_health` through MQTT and that it transitions to `running`.
 
 ## Configuration
 Configuration is split into:
 - `app_config`: instance-independent policy (fault catalog, strict validation, entity validation flags).
-- `user_config`: house-specific entities, component enablement, and calibration.
+- `user_config`: house-specific entities, MQTT topic settings, component enablement, and calibration.
 
 See `backend/app_cfg.yaml` for a fully annotated example. The `config_version` value must match the supported version in code.
+
+By default, internal entity discovery is published below `homeassistant/.../config`, states below `safety_component/state/...`, and attributes below `safety_component/attributes/...`. Retained discovery is kept for entity restoration, while stale retained state is cleared on startup and refreshed with a non-retained heartbeat. Recovery commands are executed through explicit Home Assistant services; MQTT is not used as an unacknowledged actuator transport.
 
 ## Code Organization
 Backend code is organized under `backend/components` by responsibility:

--- a/backend/SafetyFunctions.py
+++ b/backend/SafetyFunctions.py
@@ -79,6 +79,7 @@ class SafetyFunctions(hass.Hass):
         # Disable all the no-member violations in this function
         # pylint: disable=attribute-defined-outside-init
         if not self._initialize_mqtt():
+            self.stop_app(self.name)
             return
 
         try:
@@ -92,7 +93,7 @@ class SafetyFunctions(hass.Hass):
                 "invalid_cfg",
                 attributes={"configuration_error": str(exc)},
             )
-            self.stop_app(self.name)
+            self._start_mqtt_reporting()
             return
 
         if DEBUG:
@@ -111,24 +112,6 @@ class SafetyFunctions(hass.Hass):
         self.notification_cfg: dict = self.args["user_config"]["notification"]
         self.common_entities_cfg: dict = self.args["user_config"]["common_entities"]
 
-        # Combine configuration for export later
-        combined_config = {
-            "faults": self.fault_dict,
-            "safety_components": self.safety_components_cfg,
-            "notification": self.notification_cfg,
-            "common_entities": self.common_entities_cfg,
-        }
-
-        # 10.3. Stop if configurations are invalid
-        if not self.fault_dict or not self.safety_components_cfg:
-            self.log(
-                "No faults or safety components defined. Stopping the app.",
-                level="WARNING",
-            )
-            self._set_internal_entity("sensor.safety_app_health", "invalid_cfg")
-            self.stop_app(self.name)
-            return
-
         # 20. Initialize common entities
         self.common_entities: CommonEntities = CommonEntities(
             self, self.common_entities_cfg
@@ -138,7 +121,10 @@ class SafetyFunctions(hass.Hass):
         for component_name, component_cls in get_registered_components().items():
             if component_name in self.safety_components_cfg:
                 component_instance = component_cls(
-                    self, self.common_entities, self.event_bus
+                    self,
+                    self.common_entities,
+                    self.event_bus,
+                    self.mqtt_entities,
                 )
                 self.sm_modules[component_name] = component_instance
 
@@ -165,7 +151,7 @@ class SafetyFunctions(hass.Hass):
 
         # 60. Initialize notification manager
         self.notify_man: NotificationManager = NotificationManager(
-            self, self.notification_cfg, self.mqtt_entities
+            self, self.notification_cfg
         )
 
         # 70. Initialize recovery manager
@@ -192,7 +178,7 @@ class SafetyFunctions(hass.Hass):
         # 90. Event-driven flow means components publish to the bus instead.
 
         # 100. Register entities for faults
-        health_attributes: dict[str, Any] = self.register_entities()
+        self.register_entities()
 
         # 110. Initialize safety mechanisms
         self.fm.init_safety_mechanisms()
@@ -201,16 +187,8 @@ class SafetyFunctions(hass.Hass):
         self.fm.enable_all_symptoms()
 
         # 130 Emit config and set state to running
-        self._set_internal_entity(
-            "sensor.safety_app_health", "running", attributes=health_attributes
-        )
-        self.mqtt_entities.publish_availability(True)
-        if self.mqtt_entities.settings.heartbeat_seconds > 0:
-            self.run_every(
-                self._mqtt_heartbeat,
-                "now",
-                self.mqtt_entities.settings.heartbeat_seconds,
-            )
+        self._set_internal_entity("sensor.safety_app_health", "running")
+        self._start_mqtt_reporting()
         self.log("Safety app started successfully", level="DEBUG")
 
     def _initialize_mqtt(self) -> bool:
@@ -240,13 +218,21 @@ class SafetyFunctions(hass.Hass):
             self._set_internal_entity("sensor.safety_app_health", "init")
         except (ValidationError, ValueError) as exc:
             self.log(f"Invalid MQTT configuration: {exc}", level="ERROR")
-            self.stop_app(self.name)
             return False
         except Exception as exc:
             self.log(f"Unable to initialize MQTT publishing: {exc}", level="ERROR")
-            self.stop_app(self.name)
             return False
         return True
+
+    def _start_mqtt_reporting(self) -> None:
+        """Make MQTT entities available and keep their states fresh."""
+        self.mqtt_entities.publish_availability(True)
+        if self.mqtt_entities.settings.heartbeat_seconds > 0:
+            self.run_every(
+                self._mqtt_heartbeat,
+                "now",
+                self.mqtt_entities.settings.heartbeat_seconds,
+            )
 
     def _mqtt_heartbeat(self, **_: Any) -> None:
         """Refresh MQTT sensor states used by ``expire_after``."""
@@ -268,6 +254,7 @@ class SafetyFunctions(hass.Hass):
             "sensor.safety_app_health",
             "Safety App Health",
             icon="mdi:heart-pulse",
+            entity_category="diagnostic",
         )
 
     def _set_internal_entity(
@@ -284,14 +271,13 @@ class SafetyFunctions(hass.Hass):
             attributes=attributes,
         )
 
-    def register_entities(self) -> dict[str, Any]:
+    def register_entities(self) -> None:
         """
         Registers all entities required by the Safety Functions app in Home Assistant.
 
         This includes:
         - Initializing the `sensor.system_state` entity with a default safe state.
         - Registering fault entities for each fault in the system.
-        - Exporting the app health entity attributes.
 
         Ensures that the entities are properly initialized and available for monitoring in Home Assistant.
         """
@@ -305,6 +291,7 @@ class SafetyFunctions(hass.Hass):
                 "description": "Overall safety system state based on fault conditions.",
             },
             icon="mdi:shield-check",
+            entity_category="diagnostic",
         )
 
         # Register fault entities
@@ -319,29 +306,5 @@ class SafetyFunctions(hass.Hass):
                     "level": f"level_{fault.level}",
                 },
                 icon="mdi:alert-outline",
+                entity_category="diagnostic",
             )
-
-        # Register health entity
-        combined_config = {
-            "faults": self.fault_dict,
-            "safety_components": self.safety_components_cfg,
-            "notification": self.notification_cfg,
-            "common_entities": self.common_entities_cfg,
-        }
-        health_attributes = {
-            "friendly_name": "Safety App Health",
-            "configuration": combined_config,
-            "symptoms": {
-                name: vars(symptom) for name, symptom in self.symptoms.items()
-            },
-            "recovery_actions": {
-                name: {
-                    "name": action.name,
-                    "params": action.params,
-                    "status": action.current_status.name,
-                }
-                for name, action in self.recovery_actions.items()
-            },
-        }
-
-        return health_attributes

--- a/backend/SafetyFunctions.py
+++ b/backend/SafetyFunctions.py
@@ -35,8 +35,11 @@ Note:
 
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
+
 import appdaemon.plugins.hass.hassapi as hass
+from pydantic import ValidationError
+
 from components.app_config_validator.app_cfg_validator import (
     AppCfgValidationError,
     AppCfgValidator,
@@ -44,6 +47,7 @@ from components.app_config_validator.app_cfg_validator import (
 from components.core.common_entities import CommonEntities
 from components.core.event_bus import EventBus
 from components.core.derivative_monitor import DerivativeMonitor
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.faults_manager import cfg_parser as cfg_pr
 from components.faults_manager.fault_manager import FaultManager
 from components.notification_manager.notification_manager import NotificationManager
@@ -74,8 +78,8 @@ class SafetyFunctions(hass.Hass):
         """
         # Disable all the no-member violations in this function
         # pylint: disable=attribute-defined-outside-init
-        # 10. Initialize health entity
-        self.set_state("sensor.safety_app_health", state="init")
+        if not self._initialize_mqtt():
+            return
 
         try:
             self.args: Dict[str, Any] = AppCfgValidator.validate(
@@ -83,7 +87,11 @@ class SafetyFunctions(hass.Hass):
             )
         except AppCfgValidationError as exc:
             self.log(f"Invalid app configuration: {exc}", level="ERROR")
-            self.set_state("sensor.safety_app_health", state="invalid_cfg")
+            self._set_internal_entity(
+                "sensor.safety_app_health",
+                "invalid_cfg",
+                attributes={"configuration_error": str(exc)},
+            )
             self.stop_app(self.name)
             return
 
@@ -94,7 +102,7 @@ class SafetyFunctions(hass.Hass):
         self.sm_modules: dict = {}
         self.symptoms: dict[str, Symptom] = {}
         self.recovery_actions: dict[str, RecoveryAction] = {}
-        self.derivative_monitor = DerivativeMonitor(self)
+        self.derivative_monitor = DerivativeMonitor(self, self.mqtt_entities)
         self.event_bus = EventBus()
 
         # 10.2. Get configuration data
@@ -117,7 +125,7 @@ class SafetyFunctions(hass.Hass):
                 "No faults or safety components defined. Stopping the app.",
                 level="WARNING",
             )
-            self.set_state("sensor.safety_app_health", state="invalid_cfg")
+            self._set_internal_entity("sensor.safety_app_health", "invalid_cfg")
             self.stop_app(self.name)
             return
 
@@ -147,17 +155,27 @@ class SafetyFunctions(hass.Hass):
 
         # 50. Initialize fault manager
         self.fm: FaultManager = FaultManager(
-            self, self.sm_modules, self.symptoms, self.faults, self.event_bus
+            self,
+            self.sm_modules,
+            self.symptoms,
+            self.faults,
+            self.event_bus,
+            self.mqtt_entities,
         )
 
         # 60. Initialize notification manager
         self.notify_man: NotificationManager = NotificationManager(
-            self, self.notification_cfg
+            self, self.notification_cfg, self.mqtt_entities
         )
 
         # 70. Initialize recovery manager
         self.reco_man: RecoveryManager = RecoveryManager(
-            self, self.fm, self.recovery_actions, self.common_entities, self.notify_man
+            self,
+            self.fm,
+            self.recovery_actions,
+            self.common_entities,
+            self.notify_man,
+            self.mqtt_entities,
         )
 
         # 80. Register callbacks for faults
@@ -183,10 +201,88 @@ class SafetyFunctions(hass.Hass):
         self.fm.enable_all_symptoms()
 
         # 130 Emit config and set state to running
-        self.set_state(
-            "sensor.safety_app_health", state="running", attributes=health_attributes
+        self._set_internal_entity(
+            "sensor.safety_app_health", "running", attributes=health_attributes
         )
+        self.mqtt_entities.publish_availability(True)
+        if self.mqtt_entities.settings.heartbeat_seconds > 0:
+            self.run_every(
+                self._mqtt_heartbeat,
+                "now",
+                self.mqtt_entities.settings.heartbeat_seconds,
+            )
         self.log("Safety app started successfully", level="DEBUG")
+
+    def _initialize_mqtt(self) -> bool:
+        """Validate MQTT settings and initialize discovery in an offline state."""
+        try:
+            if not isinstance(self.args, Mapping):
+                raise ValueError("App configuration must be a mapping")
+            user_config = self.args.get("user_config", {})
+            app_config = self.args.get("app_config", {})
+            if not isinstance(user_config, Mapping):
+                raise ValueError("user_config must be a mapping")
+            if not isinstance(app_config, Mapping):
+                raise ValueError("app_config must be a mapping")
+            raw_mqtt_cfg = user_config.get("mqtt", {})
+            if not isinstance(raw_mqtt_cfg, Mapping):
+                raise ValueError("user_config.mqtt must be a mapping")
+            strict_validation = bool(app_config.get("strict_validation", True))
+
+            self.mqtt_entities = MqttEntityManager(
+                self,
+                raw_mqtt_cfg,
+                strict_validation=strict_validation,
+            )
+            self.mqtt_entities.publish_availability(False)
+            self.mqtt_entities.cleanup_legacy_discovery_topics()
+            self._register_health_entity()
+            self._set_internal_entity("sensor.safety_app_health", "init")
+        except (ValidationError, ValueError) as exc:
+            self.log(f"Invalid MQTT configuration: {exc}", level="ERROR")
+            self.stop_app(self.name)
+            return False
+        except Exception as exc:
+            self.log(f"Unable to initialize MQTT publishing: {exc}", level="ERROR")
+            self.stop_app(self.name)
+            return False
+        return True
+
+    def _mqtt_heartbeat(self, **_: Any) -> None:
+        """Refresh MQTT sensor states used by ``expire_after``."""
+        self.mqtt_entities.publish_heartbeat()
+
+    def terminate(self) -> None:
+        """Publish offline availability during a clean AppDaemon shutdown."""
+        mqtt_entities = getattr(self, "mqtt_entities", None)
+        if mqtt_entities is None:
+            return
+        try:
+            mqtt_entities.publish_availability(False)
+        except Exception as exc:
+            self.log(f"Unable to publish MQTT offline state: {exc}", level="ERROR")
+
+    def _register_health_entity(self) -> None:
+        """Register the app health entity through MQTT discovery."""
+        self.mqtt_entities.register_sensor(
+            "sensor.safety_app_health",
+            "Safety App Health",
+            icon="mdi:heart-pulse",
+        )
+
+    def _set_internal_entity(
+        self,
+        entity_id: str,
+        state: Any,
+        *,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish an internal SafetyFunctions entity state via MQTT."""
+        self.mqtt_entities.publish_sensor_state(
+            entity_id,
+            state,
+            attributes=attributes,
+        )
 
     def register_entities(self) -> dict[str, Any]:
         """
@@ -200,28 +296,29 @@ class SafetyFunctions(hass.Hass):
         Ensures that the entities are properly initialized and available for monitoring in Home Assistant.
         """
         # Register system state entity
-        self.set_state(
-            "sensor.safetySystem_state",
-            state="safe",  # Default state on initialization
+        self.mqtt_entities.register_sensor(
+            "sensor.safetysystem_state",
+            "System State",
+            state="safe",
             attributes={
-                "friendly_name": "System State",
-                "icon": "mdi:shield-check",
                 "attribution": "Managed by SafetyFunction",
                 "description": "Overall safety system state based on fault conditions.",
             },
+            icon="mdi:shield-check",
         )
 
         # Register fault entities
         for name, fault in self.faults.items():
-            self.set_state(
+            self.mqtt_entities.register_sensor(
                 "sensor.fault_" + name,
+                f"Fault: {name}",
                 state="Not_tested",
                 attributes={
-                    "friendly_name": f"Fault: {name}",
                     "attribution": "Managed by SafetyFunction",
                     "description": f"Status of the {name} fault.",
                     "level": f"level_{fault.level}",
                 },
+                icon="mdi:alert-outline",
             )
 
         # Register health entity

--- a/backend/app_cfg.yaml
+++ b/backend/app_cfg.yaml
@@ -125,6 +125,27 @@ SafetyFunctions:
     common_entities:
       outside_temp: "sensor.dom_temperature"
 
+    # MQTT entity publishing.
+    #
+    # SafetyFunctions creates its internal entities through Home Assistant MQTT
+    # discovery instead of AppDaemon set_state. State updates are published to
+    # MQTT state topics and JSON attributes to attributes topics. Recovery
+    # actuators continue to use native Home Assistant services.
+    mqtt:
+      discovery_prefix: "homeassistant"
+      base_topic: "safety_component"
+      availability_topic: "safety_component/status"
+      device_identifier: "safety_component"
+      device_name: "Safety Component"
+      retain_discovery: true
+      retain_state: false
+      clear_retained_state_on_start: true
+      qos: 0
+      heartbeat_seconds: 60
+      expire_after: 180
+      legacy_discovery_entity_ids:
+        - "sensor.safety_app_health"
+
     # Safety components configuration (house-specific calibration + entities).
     #
     # Each component has its own schema. If a component is enabled above, its
@@ -140,11 +161,11 @@ SafetyFunctions:
         # Per-room configuration
         rooms:
           Office:
-            temperature_sensor: "sensor.office_temperature"
+            temperature_sensor: "sensor.office_climatesensor_temperature"
             window_sensor: "binary_sensor.office_window_contact_contact"
 
           Bedroom:
-            temperature_sensor: "sensor.bedroom_temperature"
+            temperature_sensor: "sensor.bedroom_climatesensor_temperature"
             window_sensor: "binary_sensor.bedroom_windowleft_sensor_contact"
 
           #Bathroom:
@@ -152,15 +173,16 @@ SafetyFunctions:
           #  window_sensor: "binary_sensor.bathroom_window_contact_contact"
 
           Livingroom:
-            temperature_sensor: "sensor.livingroom_temperature"
+            temperature_sensor: "sensor.livingroom_climatesensor_temperature"
             window_sensor: "binary_sensor.livingroom_door_contact_contact"
 
           Kitchen:
-            temperature_sensor: "sensor.corridor_temperature"
+            # The downstairs HC1 thermostat is the corridor temperature source.
+            temperature_sensor: "sensor.thermostat_hc1_current_room_temperature_2"
             window_sensor: "binary_sensor.kitchen_window_contact_contact"
 
           Entrance:
-            temperature_sensor: "sensor.entrance_temperature"
+            temperature_sensor: "sensor.entrance_climatesensor_temperature"
             window_sensor: null
 
           Garage:
@@ -168,13 +190,13 @@ SafetyFunctions:
             CAL_LOW_TEMP_THRESHOLD: 10.0
             CAL_HIGH_TEMP_THRESHOLD: 28.0
             CAL_FORECAST_TIMESPAN: 2.0
-            temperature_sensor: "sensor.garage_temperature"
+            temperature_sensor: "sensor.garage_climatesensor_temperature"
             window_sensor: "binary_sensor.garage_gatedoorlow_contact_contact"
 
           Kidsroom:
-            temperature_sensor: "sensor.kidsroom_temperature"
+            temperature_sensor: "sensor.kidsroom_climatesensor_temperature"
             window_sensor: "binary_sensor.kidsroom_window_contact_contact"
 
           Upperbathroom:
-            temperature_sensor: "sensor.upperbathroom_temperature"
+            temperature_sensor: "sensor.upperbathroom_climatesensor_temperature"
             #window_sensor: "sensor.upperbathroom_window_contact_contact"

--- a/backend/app_cfg.yaml
+++ b/backend/app_cfg.yaml
@@ -143,8 +143,6 @@ SafetyFunctions:
       qos: 0
       heartbeat_seconds: 60
       expire_after: 180
-      legacy_discovery_entity_ids:
-        - "sensor.safety_app_health"
 
     # Safety components configuration (house-specific calibration + entities).
     #

--- a/backend/components/app_config_validator/app_cfg_validator.py
+++ b/backend/components/app_config_validator/app_cfg_validator.py
@@ -44,7 +44,11 @@ def _collect_entity_ids(runtime_cfg: Dict[str, Any]) -> list[tuple[str, str]]:
 
     notification_cfg = user_cfg.get("notification", {}) or {}
     for key, value in notification_cfg.items():
-        if key.endswith("_entity") and isinstance(value, str):
+        if (
+            key.endswith("_entity")
+            and not key.startswith("dashboard_")
+            and isinstance(value, str)
+        ):
             entity_ids.append((f"user_config.notification.{key}", value))
 
     components_cfg = user_cfg.get("safety_components", {}) or {}
@@ -178,6 +182,7 @@ class AppCfgValidator:
                 "app_config.calibration.temperature",
             )
             log_extra_keys(cfg.user_config, log, "user_config")
+            log_extra_keys(cfg.user_config.mqtt, log, "user_config.mqtt")
 
         entity_ids = _collect_entity_ids(runtime_cfg)
 

--- a/backend/components/app_config_validator/app_cfg_validator.py
+++ b/backend/components/app_config_validator/app_cfg_validator.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
 import re
+from typing import Any, Callable, Dict
 
 from pydantic import ValidationError
 
@@ -44,11 +44,7 @@ def _collect_entity_ids(runtime_cfg: Dict[str, Any]) -> list[tuple[str, str]]:
 
     notification_cfg = user_cfg.get("notification", {}) or {}
     for key, value in notification_cfg.items():
-        if (
-            key.endswith("_entity")
-            and not key.startswith("dashboard_")
-            and isinstance(value, str)
-        ):
+        if key.endswith("_entity") and isinstance(value, str):
             entity_ids.append((f"user_config.notification.{key}", value))
 
     components_cfg = user_cfg.get("safety_components", {}) or {}
@@ -168,6 +164,14 @@ class AppCfgValidator:
                 strict_validation=strict_validation,
                 log=log,
             )
+            if not runtime_cfg["app_config"]["faults"]:
+                raise AppCfgValidationError(
+                    "app_config.faults must define at least one fault"
+                )
+            if not runtime_cfg["user_config"]["safety_components"]:
+                raise AppCfgValidationError(
+                    "user_config.safety_components must enable at least one component"
+                )
         except (ValidationError, ValueError) as exc:
             raise AppCfgValidationError(str(exc))
 

--- a/backend/components/app_config_validator/schema.py
+++ b/backend/components/app_config_validator/schema.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar, Dict, Optional
 
 from pydantic import ConfigDict, Field
 
+from components.core.mqtt_entity_manager import MqttSettings
 from components.core.pydantic_utils import StrictBaseModel
 
 
@@ -57,6 +58,7 @@ class UserConfig(StrictBaseModel):
 
     components_enabled: Dict[str, bool] = Field(default_factory=dict)
     notification: Dict[str, Any] = Field(default_factory=dict)
+    mqtt: MqttSettings = Field(default_factory=MqttSettings)
     common_entities: Dict[str, str]
     safety_components: Dict[str, Dict[str, Any]]
 

--- a/backend/components/core/__init__.py
+++ b/backend/components/core/__init__.py
@@ -3,6 +3,7 @@
 
 from .common_entities import CommonEntities
 from .derivative_monitor import DerivativeMonitor
+from .mqtt_entity_manager import MqttEntityManager, MqttSettings
 from .pydantic_utils import StrictBaseModel, log_extra_keys
 from .types_common import (
     FaultState,
@@ -19,6 +20,8 @@ __all__ = [
     "DerivativeMonitor",
     "Fault",
     "FaultState",
+    "MqttEntityManager",
+    "MqttSettings",
     "RecoveryAction",
     "RecoveryActionState",
     "RecoveryResult",

--- a/backend/components/core/derivative_monitor.py
+++ b/backend/components/core/derivative_monitor.py
@@ -7,10 +7,13 @@ Classes:
 - DerivativeMonitor: A singleton class to register entities, calculate derivatives, and provide access to derivative data.
 """
 
-from typing import Optional, Dict, Any
-from appdaemon.plugins.hass.hassapi import Hass  # type: ignore
-from threading import Lock
 import collections
+from threading import Lock
+from typing import Any, Dict, Optional
+
+from appdaemon.plugins.hass.hassapi import Hass  # type: ignore
+
+from components.core.mqtt_entity_manager import MqttEntityManager
 
 
 class DerivativeMonitor:
@@ -31,10 +34,13 @@ class DerivativeMonitor:
                     cls._instance = super(DerivativeMonitor, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, hass_app: Hass) -> None:
+    def __init__(
+        self, hass_app: Hass, mqtt_entities: MqttEntityManager | None = None
+    ) -> None:
         """Initializes the singleton instance if not already initialized."""
         if not hasattr(self, "initialized"):
             self.hass_app = hass_app
+            self.mqtt_entities = mqtt_entities
             self.entities: Dict[str, Dict[str, Any]] = {}
             self.derivative_data: Dict[str, Dict[str, Optional[float]]] = {}
             self.filter_window_size = (
@@ -44,9 +50,11 @@ class DerivativeMonitor:
             self.initialized = True
             self.hass_app.log("DerivativeMonitor initialized.", level="DEBUG")
         elif self.hass_app is not hass_app:
-            self.reset_for_app(hass_app)
+            self.reset_for_app(hass_app, mqtt_entities)
 
-    def reset_for_app(self, hass_app: Hass) -> None:
+    def reset_for_app(
+        self, hass_app: Hass, mqtt_entities: MqttEntityManager | None = None
+    ) -> None:
         """
         Reset internal state when a new app instance starts.
 
@@ -59,6 +67,7 @@ class DerivativeMonitor:
         if old_hass_app is not None:
             self._cancel_sampling_handles(old_hass_app)
         self.hass_app = hass_app
+        self.mqtt_entities = mqtt_entities
         self.entities = {}
         self.derivative_data = {}
         self._sampling_handles = {}
@@ -115,6 +124,36 @@ class DerivativeMonitor:
         }
         self.entities[entity_id]["first_derivative_history"].append(0.00)
         self.entities[entity_id]["second_derivative_history"].append(0.00)
+        if self.mqtt_entities:
+            self._register_derivative_entity(
+                f"{entity_id}_rate",
+                f"{entity_id} Rate",
+                {
+                    "friendly_name": f"{entity_id} Rate",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "°C/min",
+                    "attribution": "Data provided by SafetyFunction",
+                    "icon": "mdi:chart-timeline-variant",
+                },
+            )
+            self._register_derivative_entity(
+                f"{entity_id}_rateOfRate",
+                f"{entity_id} Rate Of Rate",
+                {
+                    "friendly_name": f"{entity_id} Rate Of Rate",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "°C/min²",
+                    "attribution": "Data provided by SafetyFunction",
+                    "icon": "mdi:chart-timeline-variant",
+                },
+            )
+            self.hass_app.log(
+                f"Derivative entities created for {entity_id}.", level="DEBUG"
+            )
+            handle = self.schedule_sampling(entity_id, sample_time)
+            self._sampling_handles[entity_id] = handle
+            return
+
         # Create derivative entities in Home Assistant with additional attributes
         self.hass_app.set_state(
             f"{entity_id}_rate",
@@ -124,7 +163,6 @@ class DerivativeMonitor:
                 "state_class": "measurement",
                 "unit_of_measurement": "°C/min",
                 "attribution": "Data provided by SafetyFunction",
-                "device_class": "temperature",
                 "icon": "mdi:chart-timeline-variant",
             },
         )
@@ -132,11 +170,10 @@ class DerivativeMonitor:
             f"{entity_id}_rateOfRate",
             state=None,
             attributes={
-                "friendly_name": f"{entity_id} Rate",
+                "friendly_name": f"{entity_id} Rate Of Rate",
                 "state_class": "measurement",
-                "unit_of_measurement": "°C/min",
+                "unit_of_measurement": "°C/min²",
                 "attribution": "Data provided by SafetyFunction",
-                "device_class": "temperature",
                 "icon": "mdi:chart-timeline-variant",
             },
         )
@@ -162,10 +199,14 @@ class DerivativeMonitor:
             level="DEBUG",
         )
         return self.hass_app.run_every(
-            self._calculate_diff, "now", sample_time, entity_id=entity_id, sample_time = sample_time
+            self._calculate_diff,
+            "now",
+            sample_time,
+            entity_id=entity_id,
+            sample_time=sample_time,
         )
 
-    def _calculate_diff(self, **kwargs: Dict[str, Any]) -> None:
+    def _calculate_diff(self, **kwargs: Any) -> None:
         """
         Calculates the first and second derivatives for a registered entity's state
         and updates the corresponding Home Assistant entities.
@@ -173,14 +214,20 @@ class DerivativeMonitor:
         Args:
             kwargs (dict): Contains "entity_id" key identifying the entity to process.
         """
-        entity_id: Dict[str, Any] | None = kwargs.get("entity_id")
+        entity_id: str | None = kwargs.get("entity_id")
         if not entity_id or entity_id not in self.entities:
             self.hass_app.log(
                 f"Entity {entity_id} not registered for derivatives.", level="ERROR"
             )
             return
-        
-        sample_time: Dict[str, Any] | None = kwargs.get("sample_time")
+
+        sample_time: int | float | None = kwargs.get("sample_time")
+        if sample_time is None or sample_time <= 0:
+            self.hass_app.log(
+                f"Invalid derivative sample time for {entity_id}: {sample_time}.",
+                level="ERROR",
+            )
+            return
 
         self.hass_app.log(f"Calculating derivatives for {entity_id}.", level="DEBUG")
         entity_config: Dict[str, Any] = self.entities[entity_id]
@@ -195,7 +242,7 @@ class DerivativeMonitor:
         # Calculate first and second derivatives
         prev_value = entity_config["prev_value"]
         if prev_value is not None:
-            first_derivative = (current_value - prev_value) * 60.0 / sample_time 
+            first_derivative = (current_value - prev_value) * 60.0 / sample_time
             first_derivative = max(
                 entity_config["low_saturation"],
                 min(first_derivative, entity_config["high_saturation"]),
@@ -204,7 +251,7 @@ class DerivativeMonitor:
             second_derivative = (
                 None
                 if prev_first_derivative is None
-                else (first_derivative - prev_first_derivative) * 60.0 / sample_time 
+                else (first_derivative - prev_first_derivative) * 60.0 / sample_time
             )
             if second_derivative is not None:
                 second_derivative = max(
@@ -213,9 +260,9 @@ class DerivativeMonitor:
                 )
 
             # Add to history for filtering
-            if first_derivative:
+            if first_derivative is not None:
                 entity_config["first_derivative_history"].append(first_derivative)
-            if second_derivative:
+            if second_derivative is not None:
                 entity_config["second_derivative_history"].append(second_derivative)
 
             # Apply moving average filtering and round to 2 digits
@@ -240,13 +287,12 @@ class DerivativeMonitor:
         entity_config["prev_value"] = current_value
 
         # Update derivative states in Home Assistant
-        self.hass_app.set_state(
-            f"{entity_id}_rate", state=entity_config["first_derivative"]
+        self._publish_derivative_state(
+            f"{entity_id}_rate", entity_config["first_derivative"]
         )
-        # Lets dont update second div
-        # self.hass_app.set_state(
-        #     f"{entity_id}_rateOfRate", state=entity_config["second_derivative"]
-        # )
+        self._publish_derivative_state(
+            f"{entity_id}_rateOfRate", entity_config["second_derivative"]
+        )
         self.hass_app.log(
             f"Updated Home Assistant states for {entity_id}.", level="DEBUG"
         )
@@ -272,6 +318,32 @@ class DerivativeMonitor:
                 f"Unable to retrieve or convert state for {entity_id}.", level="ERROR"
             )
             return None
+
+    def _register_derivative_entity(
+        self,
+        entity_id: str,
+        name: str,
+        attributes: dict[str, Any],
+    ) -> None:
+        """Register a derivative sensor through MQTT discovery."""
+        if self.mqtt_entities:
+            self.mqtt_entities.register_sensor(
+                entity_id,
+                name,
+                state=None,
+                attributes=attributes,
+                icon=attributes.get("icon"),
+                unit_of_measurement=attributes.get("unit_of_measurement"),
+                state_class=attributes.get("state_class"),
+            )
+
+    def _publish_derivative_state(self, entity_id: str, state: Any) -> None:
+        """Publish a derivative state through MQTT or the direct test fallback."""
+        if self.mqtt_entities:
+            self.mqtt_entities.publish_sensor_state(entity_id, state)
+            return
+
+        self.hass_app.set_state(entity_id, state=state)
 
     def get_first_derivative(self, entity_id: str) -> Optional[float]:
         """

--- a/backend/components/core/derivative_monitor.py
+++ b/backend/components/core/derivative_monitor.py
@@ -35,7 +35,7 @@ class DerivativeMonitor:
         return cls._instance
 
     def __init__(
-        self, hass_app: Hass, mqtt_entities: MqttEntityManager | None = None
+        self, hass_app: Hass, mqtt_entities: MqttEntityManager
     ) -> None:
         """Initializes the singleton instance if not already initialized."""
         if not hasattr(self, "initialized"):
@@ -53,7 +53,7 @@ class DerivativeMonitor:
             self.reset_for_app(hass_app, mqtt_entities)
 
     def reset_for_app(
-        self, hass_app: Hass, mqtt_entities: MqttEntityManager | None = None
+        self, hass_app: Hass, mqtt_entities: MqttEntityManager
     ) -> None:
         """
         Reset internal state when a new app instance starts.
@@ -124,41 +124,10 @@ class DerivativeMonitor:
         }
         self.entities[entity_id]["first_derivative_history"].append(0.00)
         self.entities[entity_id]["second_derivative_history"].append(0.00)
-        if self.mqtt_entities:
-            self._register_derivative_entity(
-                f"{entity_id}_rate",
-                f"{entity_id} Rate",
-                {
-                    "friendly_name": f"{entity_id} Rate",
-                    "state_class": "measurement",
-                    "unit_of_measurement": "°C/min",
-                    "attribution": "Data provided by SafetyFunction",
-                    "icon": "mdi:chart-timeline-variant",
-                },
-            )
-            self._register_derivative_entity(
-                f"{entity_id}_rateOfRate",
-                f"{entity_id} Rate Of Rate",
-                {
-                    "friendly_name": f"{entity_id} Rate Of Rate",
-                    "state_class": "measurement",
-                    "unit_of_measurement": "°C/min²",
-                    "attribution": "Data provided by SafetyFunction",
-                    "icon": "mdi:chart-timeline-variant",
-                },
-            )
-            self.hass_app.log(
-                f"Derivative entities created for {entity_id}.", level="DEBUG"
-            )
-            handle = self.schedule_sampling(entity_id, sample_time)
-            self._sampling_handles[entity_id] = handle
-            return
-
-        # Create derivative entities in Home Assistant with additional attributes
-        self.hass_app.set_state(
+        self._register_derivative_entity(
             f"{entity_id}_rate",
-            state=None,
-            attributes={
+            f"{entity_id} Rate",
+            {
                 "friendly_name": f"{entity_id} Rate",
                 "state_class": "measurement",
                 "unit_of_measurement": "°C/min",
@@ -166,10 +135,10 @@ class DerivativeMonitor:
                 "icon": "mdi:chart-timeline-variant",
             },
         )
-        self.hass_app.set_state(
+        self._register_derivative_entity(
             f"{entity_id}_rateOfRate",
-            state=None,
-            attributes={
+            f"{entity_id} Rate Of Rate",
+            {
                 "friendly_name": f"{entity_id} Rate Of Rate",
                 "state_class": "measurement",
                 "unit_of_measurement": "°C/min²",
@@ -326,24 +295,20 @@ class DerivativeMonitor:
         attributes: dict[str, Any],
     ) -> None:
         """Register a derivative sensor through MQTT discovery."""
-        if self.mqtt_entities:
-            self.mqtt_entities.register_sensor(
-                entity_id,
-                name,
-                state=None,
-                attributes=attributes,
-                icon=attributes.get("icon"),
-                unit_of_measurement=attributes.get("unit_of_measurement"),
-                state_class=attributes.get("state_class"),
-            )
+        self.mqtt_entities.register_sensor(
+            entity_id,
+            name,
+            state=None,
+            attributes=attributes,
+            icon=attributes.get("icon"),
+            unit_of_measurement=attributes.get("unit_of_measurement"),
+            state_class=attributes.get("state_class"),
+            entity_category="diagnostic",
+        )
 
     def _publish_derivative_state(self, entity_id: str, state: Any) -> None:
-        """Publish a derivative state through MQTT or the direct test fallback."""
-        if self.mqtt_entities:
-            self.mqtt_entities.publish_sensor_state(entity_id, state)
-            return
-
-        self.hass_app.set_state(entity_id, state=state)
+        """Publish a derivative state through MQTT."""
+        self.mqtt_entities.publish_sensor_state(entity_id, state)
 
     def get_first_derivative(self, entity_id: str) -> Optional[float]:
         """

--- a/backend/components/core/mqtt_entity_manager.py
+++ b/backend/components/core/mqtt_entity_manager.py
@@ -1,0 +1,440 @@
+"""MQTT discovery and state publishing for SafetyFunctions internal entities."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping
+
+import appdaemon.plugins.hass.hassapi as hass  # type: ignore
+from pydantic import (
+    Field,
+    StrictBool,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
+
+from components.core.pydantic_utils import StrictBaseModel
+
+
+_UNSET = object()
+_MQTT_TOPIC_FORBIDDEN_CHARACTERS = frozenset({"+", "#", "\x00"})
+
+
+class MqttSettings(StrictBaseModel):
+    """Validated MQTT discovery, state, and lifecycle settings."""
+
+    discovery_prefix: StrictStr = "homeassistant"
+    base_topic: StrictStr = "safety_component"
+    availability_topic: StrictStr | None = None
+    device_identifier: StrictStr = "safety_component"
+    device_name: StrictStr = "Safety Component"
+    retain_discovery: StrictBool = True
+    retain_state: StrictBool = False
+    clear_retained_state_on_start: StrictBool = True
+    qos: StrictInt = Field(default=0, ge=0, le=2)
+    heartbeat_seconds: StrictInt = Field(default=60, ge=0)
+    expire_after: StrictInt = Field(default=180, ge=0)
+    legacy_discovery_entity_ids: list[StrictStr] = Field(default_factory=list)
+
+    @field_validator("discovery_prefix", "base_topic", mode="before")
+    @classmethod
+    def _normalize_required_topic(cls, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+        return cls._normalize_topic(value)
+
+    @field_validator("availability_topic", mode="before")
+    @classmethod
+    def _normalize_optional_topic(cls, value: Any) -> Any:
+        if value is None or not isinstance(value, str):
+            return value
+        return cls._normalize_topic(value)
+
+    @field_validator("legacy_discovery_entity_ids")
+    @classmethod
+    def _validate_legacy_entity_ids(cls, value: list[str]) -> list[str]:
+        for entity_id in value:
+            if not re.fullmatch(r"sensor\.[a-z0-9_]+", entity_id):
+                raise ValueError(
+                    "legacy_discovery_entity_ids must contain lowercase "
+                    "sensor entity IDs"
+                )
+        return value
+
+    @field_validator("device_identifier")
+    @classmethod
+    def _validate_device_identifier(cls, value: str) -> str:
+        identifier = value.strip()
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", identifier):
+            raise ValueError(
+                "device_identifier must contain only lowercase letters, "
+                "digits, underscores, or hyphens"
+            )
+        return identifier
+
+    @field_validator("device_name")
+    @classmethod
+    def _validate_device_name(cls, value: str) -> str:
+        name = value.strip()
+        if not name:
+            raise ValueError("device_name must not be empty")
+        return name
+
+    @model_validator(mode="after")
+    def _complete_and_validate_lifecycle(self) -> "MqttSettings":
+        if self.availability_topic is None:
+            self.availability_topic = f"{self.base_topic}/status"
+
+        if not self.retain_discovery:
+            raise ValueError(
+                "retain_discovery must be true so entities survive MQTT reloads"
+            )
+        if self.heartbeat_seconds == 0 and self.expire_after != 0:
+            raise ValueError(
+                "expire_after must be 0 when heartbeat_seconds is disabled"
+            )
+        if (
+            self.heartbeat_seconds > 0
+            and self.expire_after <= self.heartbeat_seconds
+        ):
+            raise ValueError(
+                "expire_after must be greater than heartbeat_seconds"
+            )
+        return self
+
+    @staticmethod
+    def _normalize_topic(value: str) -> str:
+        topic = value.strip().strip("/")
+        if not topic:
+            raise ValueError("MQTT topics must not be empty")
+        if any(character in topic for character in _MQTT_TOPIC_FORBIDDEN_CHARACTERS):
+            raise ValueError("MQTT topics must not contain '+', '#', or NUL")
+        if "//" in topic:
+            raise ValueError("MQTT topics must not contain empty path segments")
+        return topic
+
+
+class MqttEntityManager:
+    """
+    Publish SafetyFunctions entities through Home Assistant MQTT discovery.
+
+    The manager owns discovery, state, JSON attributes, availability, retained
+    cleanup, and heartbeat publication for internal SafetyFunctions sensors.
+    """
+
+    def __init__(
+        self,
+        hass_app: hass.Hass,
+        mqtt_config: MqttSettings | Mapping[str, Any] | None = None,
+        *,
+        strict_validation: bool = True,
+    ) -> None:
+        self.hass_app = hass_app
+        if isinstance(mqtt_config, MqttSettings):
+            self.settings = mqtt_config
+        else:
+            self.settings = MqttSettings.model_validate(
+                dict(mqtt_config or {}),
+                context={"strict_validation": strict_validation},
+            )
+
+        self.discovery_prefix = self.settings.discovery_prefix
+        self.base_topic = self.settings.base_topic
+        self.availability_topic = str(self.settings.availability_topic)
+        self.device_identifier = self.settings.device_identifier
+        self.device_name = self.settings.device_name
+        self.retain_discovery = self.settings.retain_discovery
+        self.retain_state = self.settings.retain_state
+        self.qos = self.settings.qos
+
+        self.entity_attributes: dict[str, dict[str, Any]] = {}
+        self.entity_states: dict[str, Any] = {}
+        self.discovered_entities: set[str] = set()
+        self._discovery_payloads: dict[str, str] = {}
+        self._prepared_entities: set[str] = set()
+
+    def cleanup_legacy_discovery_topics(self) -> None:
+        """Remove explicitly configured legacy retained discovery messages."""
+        for entity_id in self.settings.legacy_discovery_entity_ids:
+            self._publish(self.legacy_discovery_topic(entity_id), "", retain=True)
+
+    def publish_availability(self, online: bool = True) -> None:
+        """Publish app availability to the configured MQTT availability topic."""
+        self._publish(
+            self.availability_topic,
+            "online" if online else "offline",
+            retain=True,
+        )
+
+    def register_sensor(
+        self,
+        entity_id: str,
+        name: str,
+        *,
+        state: Any = _UNSET,
+        attributes: dict[str, Any] | None = None,
+        icon: str | None = None,
+        device_class: str | None = None,
+        unit_of_measurement: str | None = None,
+        state_class: str | None = None,
+        entity_category: str | None = None,
+    ) -> str:
+        """
+        Register an MQTT sensor and optionally publish its initial state.
+
+        Returns:
+            str: The canonical Home Assistant entity ID.
+        """
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        self._prepare_entity_topics(canonical_id)
+
+        discovery_payload = self._sensor_discovery_payload(
+            canonical_id,
+            name,
+            icon=icon,
+            device_class=device_class,
+            unit_of_measurement=unit_of_measurement,
+            state_class=state_class,
+            entity_category=entity_category,
+        )
+        encoded_discovery = json.dumps(
+            discovery_payload, sort_keys=True, default=str
+        )
+        if self._discovery_payloads.get(canonical_id) != encoded_discovery:
+            self._publish(
+                self.discovery_topic(canonical_id),
+                encoded_discovery,
+                retain=self.retain_discovery,
+            )
+            self._discovery_payloads[canonical_id] = encoded_discovery
+
+        self.discovered_entities.add(canonical_id)
+
+        if attributes is not None:
+            self.publish_sensor_attributes(canonical_id, attributes)
+        if state is not _UNSET:
+            self.publish_sensor_state(canonical_id, state)
+        return canonical_id
+
+    def publish_sensor_state(
+        self,
+        entity_id: str,
+        state: Any,
+        *,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish a sensor state and optional JSON attributes."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        if canonical_id not in self.discovered_entities:
+            self.register_sensor(
+                canonical_id,
+                self._friendly_name(canonical_id),
+                state=state,
+                attributes=attributes,
+            )
+            return
+
+        if attributes is not None:
+            self.publish_sensor_attributes(canonical_id, attributes)
+
+        self.entity_states[canonical_id] = state
+        self._publish(
+            self.state_topic(canonical_id),
+            self._state_payload(state),
+            retain=self.retain_state,
+        )
+
+    def publish_sensor_attributes(
+        self, entity_id: str, attributes: Mapping[str, Any]
+    ) -> None:
+        """Publish JSON attributes for a registered sensor."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        self.entity_attributes[canonical_id] = dict(attributes)
+        self._publish_json(
+            self.attributes_topic(canonical_id),
+            self.entity_attributes[canonical_id],
+            retain=self.retain_state,
+        )
+
+    def publish_heartbeat(self) -> None:
+        """Refresh cached state and attributes after restarts and for expiry."""
+        for entity_id, state in list(self.entity_states.items()):
+            self._publish(
+                self.state_topic(entity_id),
+                self._state_payload(state),
+                retain=self.retain_state,
+            )
+        for entity_id, attributes in list(self.entity_attributes.items()):
+            self._publish_json(
+                self.attributes_topic(entity_id),
+                attributes,
+                retain=self.retain_state,
+            )
+
+    def get_attributes(self, entity_id: str) -> dict[str, Any]:
+        """Return the last attributes published for an MQTT entity."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        return dict(self.entity_attributes.get(canonical_id, {}))
+
+    def remove_sensor(self, entity_id: str, *, remove_legacy_topic: bool = False) -> None:
+        """Remove a sensor's retained discovery, state, and attribute messages."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        topics = [
+            self.discovery_topic(canonical_id),
+            self.state_topic(canonical_id),
+            self.attributes_topic(canonical_id),
+        ]
+        if remove_legacy_topic:
+            topics.append(self.legacy_discovery_topic(canonical_id))
+
+        for topic in dict.fromkeys(topics):
+            self._publish(topic, "", retain=True)
+
+        self.discovered_entities.discard(canonical_id)
+        self._prepared_entities.discard(canonical_id)
+        self._discovery_payloads.pop(canonical_id, None)
+        self.entity_states.pop(canonical_id, None)
+        self.entity_attributes.pop(canonical_id, None)
+
+    def state_topic(self, entity_id: str) -> str:
+        """Return the state topic for an entity."""
+        canonical_id = self.canonical_entity_id(entity_id)
+        return f"{self.base_topic}/state/{self._object_id(canonical_id)}"
+
+    def attributes_topic(self, entity_id: str) -> str:
+        """Return the JSON attributes topic for an entity."""
+        canonical_id = self.canonical_entity_id(entity_id)
+        return f"{self.base_topic}/attributes/{self._object_id(canonical_id)}"
+
+    def discovery_topic(self, entity_id: str) -> str:
+        """Return the collision-resistant discovery topic for a sensor."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        return (
+            f"{self.discovery_prefix}/sensor/"
+            f"{self._unique_id(canonical_id)}/config"
+        )
+
+    def legacy_discovery_topic(self, entity_id: str) -> str:
+        """Return the discovery topic generated by the pre-migration code."""
+        canonical_id = self.canonical_entity_id(entity_id, expected_domain="sensor")
+        return (
+            f"{self.discovery_prefix}/sensor/"
+            f"{self._object_id(canonical_id)}/config"
+        )
+
+    def _prepare_entity_topics(self, entity_id: str) -> None:
+        if entity_id in self._prepared_entities:
+            return
+        if self.settings.clear_retained_state_on_start:
+            self._publish(self.state_topic(entity_id), "", retain=True)
+            self._publish(self.attributes_topic(entity_id), "", retain=True)
+        self._prepared_entities.add(entity_id)
+
+    def _sensor_discovery_payload(
+        self,
+        entity_id: str,
+        name: str,
+        *,
+        icon: str | None,
+        device_class: str | None,
+        unit_of_measurement: str | None,
+        state_class: str | None,
+        entity_category: str | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": name,
+            "unique_id": self._unique_id(entity_id),
+            "default_entity_id": entity_id,
+            "state_topic": self.state_topic(entity_id),
+            "json_attributes_topic": self.attributes_topic(entity_id),
+            "availability_topic": self.availability_topic,
+            "qos": self.qos,
+            "device": {
+                "identifiers": [self.device_identifier],
+                "name": self.device_name,
+                "manufacturer": "SafetyComponent",
+                "model": "AppDaemon Safety Component",
+            },
+            "origin": {
+                "name": "SafetyComponent",
+                "sw_version": "1",
+                "support_url": "https://github.com/Arkaqius/SafetyComponent",
+            },
+        }
+        if self.settings.expire_after > 0:
+            payload["expire_after"] = self.settings.expire_after
+
+        optional_values = {
+            "icon": icon,
+            "device_class": device_class,
+            "unit_of_measurement": unit_of_measurement,
+            "state_class": state_class,
+            "entity_category": entity_category,
+        }
+        payload.update(
+            {key: value for key, value in optional_values.items() if value is not None}
+        )
+        return payload
+
+    def _unique_id(self, entity_id: str) -> str:
+        return f"{self._slug(self.device_identifier)}_{self._object_id(entity_id)}"
+
+    def _object_id(self, entity_id: str) -> str:
+        return entity_id.split(".", 1)[1]
+
+    @classmethod
+    def canonical_entity_id(
+        cls, entity_id: str, *, expected_domain: str | None = None
+    ) -> str:
+        """Return a lowercase valid entity ID while preserving legacy tokens."""
+        if not isinstance(entity_id, str) or entity_id.count(".") != 1:
+            raise ValueError(f"Invalid Home Assistant entity_id: {entity_id!r}")
+        raw_domain, raw_object_id = entity_id.split(".", 1)
+        domain = cls._slug(raw_domain)
+        object_id = cls._slug(raw_object_id)
+        if not domain or not object_id:
+            raise ValueError(f"Invalid Home Assistant entity_id: {entity_id!r}")
+        if expected_domain and domain != expected_domain:
+            raise ValueError(
+                f"Expected a {expected_domain} entity, got {entity_id!r}"
+            )
+        return f"{domain}.{object_id}"
+
+    @staticmethod
+    def _slug(value: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9]+", "_", value)
+        slug = re.sub(r"_+", "_", slug).strip("_")
+        return slug.lower()
+
+    @staticmethod
+    def _friendly_name(entity_id: str) -> str:
+        return entity_id.split(".", 1)[-1].replace("_", " ").title()
+
+    @staticmethod
+    def _state_payload(state: Any) -> str:
+        if state is None:
+            return "None"
+        return str(state)
+
+    def _publish_json(
+        self, topic: str, payload: Mapping[str, Any], *, retain: bool
+    ) -> None:
+        self._publish(
+            topic,
+            json.dumps(dict(payload), sort_keys=True, default=str),
+            retain=retain,
+        )
+
+    def _publish(self, topic: str, payload: str, *, retain: bool) -> None:
+        response = self.hass_app.call_service(
+            "mqtt/publish",
+            topic=topic,
+            payload=payload,
+            retain=retain,
+            qos=self.qos,
+        )
+        if isinstance(response, Mapping) and response.get("success") is False:
+            raise RuntimeError(f"MQTT publish failed for {topic}: {response}")

--- a/backend/components/faults_manager/fault_manager.py
+++ b/backend/components/faults_manager/fault_manager.py
@@ -23,10 +23,10 @@ This module is integral to the safety system's ability to maintain operational i
 Note: This module is designed for internal use within the Home Assistant safety system and relies on configurations and interactions with other system components, including safety mechanisms and recovery action definitions.
 """
 
-from typing import Optional, Callable, Any
+import hashlib
+from typing import Any, Optional
 
 import appdaemon.plugins.hass.hassapi as hass
-import hashlib
 
 from components.core.types_common import FaultState, SMState, Symptom, Fault
 from components.core.event_bus import EventBus
@@ -61,36 +61,20 @@ class FaultManager:
         sm_modules: dict,
         symptom_dict: dict,
         fault_dict: dict,
-        event_bus: EventBus | None = None,
-        mqtt_entities: MqttEntityManager | None = None,
+        event_bus: EventBus,
+        mqtt_entities: MqttEntityManager,
     ) -> None:
         """
         Initialize the Fault Manager.
 
         :param config_path: Path to the YAML configuration file.
         """
-        self.notify_interface: (
-            Callable[[str, int, FaultState, dict | None], None] | None
-        ) = None
-        self.recovery_interface: Callable[[Symptom], None] | None = None
         self.faults: dict[str, Fault] = fault_dict
         self.symptoms: dict[str, Symptom] = symptom_dict
         self.sm_modules: dict = sm_modules
         self.hass: hass.Hass = hass
         self.event_bus = event_bus
         self.mqtt_entities = mqtt_entities
-
-    def register_callbacks(
-        self,
-        recovery_interface: Callable[[Symptom], None],
-        notify_interface: Callable[[str, int, FaultState, dict | None], None],
-    ) -> None:
-        self.hass.log(
-            "register_callbacks is deprecated; use EventBus subscriptions instead.",
-            level="WARNING",
-        )
-        self.recovery_interface = recovery_interface
-        self.notify_interface = notify_interface
 
     def handle_symptom_event(
         self,
@@ -280,37 +264,18 @@ class FaultManager:
                 "sensor.fault_" + fault.name, "Set", attributes
             )
 
-            if self.event_bus:
-                self.event_bus.publish(
-                    "fault",
-                    fault_name=fault.name,
-                    level=fault.level,
-                    fault_state=FaultState.SET,
-                    additional_info=self._notification_info_from_merged(
-                        additional_info, info_to_send
-                    ),
-                    fault_tag=fault_tag,
-                    symptom=self.symptoms[symptom_id],
-                    should_notify=True,
-                )
-            else:
-                # Call notifications
-                if self.notify_interface:
-                    self.notify_interface(
-                        fault.name,
-                        fault.level,
-                        FaultState.SET,
-                        additional_info,
-                        fault_tag,
-                    )
-                else:
-                    self.hass.log("No notification interface", level="WARNING")
-
-                # Call recovery actions (specific for symptom)
-                if self.recovery_interface:
-                    self.recovery_interface(self.symptoms[symptom_id], fault_tag)
-                else:
-                    self.hass.log("No recovery interface", level="WARNING")
+            self.event_bus.publish(
+                "fault",
+                fault_name=fault.name,
+                level=fault.level,
+                fault_state=FaultState.SET,
+                additional_info=self._notification_info_from_merged(
+                    additional_info, info_to_send
+                ),
+                fault_tag=fault_tag,
+                symptom=self.symptoms[symptom_id],
+                should_notify=True,
+            )
 
             self._apply_shadowing(fault, self.symptoms[symptom_id], additional_info)
 
@@ -461,25 +426,16 @@ class FaultManager:
 
         self._set_internal_entity(entity_id, "Shadowed", attributes)
 
-        if self.event_bus:
-            self.event_bus.publish(
-                "fault",
-                fault_name=fault.name,
-                level=fault.level,
-                fault_state=FaultState.SHADOWED,
-                additional_info=additional_info,
-                fault_tag=fault_tag,
-                symptom=symptom,
-                should_notify=True,
-            )
-        elif self.notify_interface:
-            self.notify_interface(
-                fault.name,
-                fault.level,
-                FaultState.SHADOWED,
-                additional_info,
-                fault_tag,
-            )
+        self.event_bus.publish(
+            "fault",
+            fault_name=fault.name,
+            level=fault.level,
+            fault_state=FaultState.SHADOWED,
+            additional_info=additional_info,
+            fault_tag=fault_tag,
+            symptom=symptom,
+            should_notify=True,
+        )
 
     def _clear_fault(self, symptom_id: str, additional_info: dict) -> None:
         """
@@ -530,19 +486,18 @@ class FaultManager:
 
             self._set_internal_entity(entity_id, "Set", attributes)
 
-            if self.event_bus:
-                self.event_bus.publish(
-                    "fault",
-                    fault_name=fault.name,
-                    level=fault.level,
-                    fault_state=FaultState.SET,
-                    additional_info=self._notification_info_from_merged(
-                        additional_info, info_to_send
-                    ),
-                    fault_tag=fault_tag,
-                    symptom=self.symptoms[symptom_id],
-                    should_notify=fault.state == FaultState.SET,
-                )
+            self.event_bus.publish(
+                "fault",
+                fault_name=fault.name,
+                level=fault.level,
+                fault_state=FaultState.SET,
+                additional_info=self._notification_info_from_merged(
+                    additional_info, info_to_send
+                ),
+                fault_tag=fault_tag,
+                symptom=self.symptoms[symptom_id],
+                should_notify=fault.state == FaultState.SET,
+            )
             return
 
         if not has_active_related_symptoms:
@@ -565,36 +520,16 @@ class FaultManager:
             self.update_system_state_entity()  # Update the system state entity
 
             should_notify = fault.previous_val == FaultState.SET
-            if self.event_bus:
-                self.event_bus.publish(
-                    "fault",
-                    fault_name=fault.name,
-                    level=fault.level,
-                    fault_state=FaultState.CLEARED,
-                    additional_info=additional_info,
-                    fault_tag=fault_tag,
-                    symptom=self.symptoms[symptom_id],
-                    should_notify=should_notify,
-                )
-            else:
-                if should_notify:
-                    # Call notifications
-                    if self.notify_interface:
-                        self.notify_interface(
-                            fault.name,
-                            fault.level,
-                            FaultState.CLEARED,
-                            additional_info,
-                            fault_tag,
-                        )
-                    else:
-                        self.hass.log("No notification interface", level="WARNING")
-
-                # Call recovery actions (specific for symptom)
-                if self.recovery_interface:
-                    self.recovery_interface(self.symptoms[symptom_id], fault_tag)
-                else:
-                    self.hass.log("No recovery interface", level="WARNING")
+            self.event_bus.publish(
+                "fault",
+                fault_name=fault.name,
+                level=fault.level,
+                fault_state=FaultState.CLEARED,
+                additional_info=additional_info,
+                fault_tag=fault_tag,
+                symptom=self.symptoms[symptom_id],
+                should_notify=should_notify,
+            )
 
     def check_fault(self, fault_id: str) -> FaultState:
         """
@@ -794,23 +729,13 @@ class FaultManager:
         )
 
     def _get_entity_attributes(self, entity_id: str) -> dict:
-        """Return attributes for an internal entity from MQTT state or HA fallback."""
-        if self.mqtt_entities:
-            return self.mqtt_entities.get_attributes(entity_id)
-
-        state = self.hass.get_state(entity_id, attribute="all")
-        if not state:
-            return {}
-        return state.get("attributes", {})
+        """Return attributes cached for an internal MQTT entity."""
+        return self.mqtt_entities.get_attributes(entity_id)
 
     def _set_internal_entity(
         self, entity_id: str, state: str, attributes: Optional[dict] = None
     ) -> None:
-        """Publish an internal entity through MQTT discovery or test fallback."""
-        if self.mqtt_entities:
-            self.mqtt_entities.publish_sensor_state(
-                entity_id, state, attributes=attributes
-            )
-            return
-
-        self.hass.set_state(entity_id, state=state, attributes=attributes or {})
+        """Publish an internal entity through MQTT."""
+        self.mqtt_entities.publish_sensor_state(
+            entity_id, state, attributes=attributes
+        )

--- a/backend/components/faults_manager/fault_manager.py
+++ b/backend/components/faults_manager/fault_manager.py
@@ -15,8 +15,8 @@ Primary functionalities include:
 Initializing and tracking the states of faults and symptoms based on system configuration and runtime observations.
 Dynamically updating fault states in response to changes in associated symptom conditions.
 Executing defined recovery actions and notifications as part of the fault resolution process.
-Generating a unique faulttag for each fault instance to uniquely identify and manage notifications and recovery actions associated with specific faults.
-The faulttag feature is used across the system to create a unique identifier for each fault by hashing the fault name and additional context information. This allows consistent tracking and correlation of notifications, fault states, and recovery actions, ensuring accurate fault management.
+Generating a stable faulttag for each fault to identify and manage notifications and recovery actions associated with specific faults.
+The faulttag feature is used across the system to create a stable identifier for each fault by hashing the fault name. This keeps multiple symptom contributions for the same fault correlated to one notification and recovery flow.
 
 This module is integral to the safety system's ability to maintain operational integrity and respond effectively to detected issues, ensuring a high level of safety and reliability.
 
@@ -255,7 +255,7 @@ class FaultManager:
                 )
                 return
 
-            # Generate a unique fault tag using the hash method
+            # Generate a stable fault tag using the hash method
             fault_tag: str = self._generate_fault_tag(fault.name, additional_info)
             # Save previous value
             fault.previous_val = fault.state
@@ -283,7 +283,9 @@ class FaultManager:
                     fault_name=fault.name,
                     level=fault.level,
                     fault_state=FaultState.SET,
-                    additional_info=additional_info,
+                    additional_info=self._notification_info_from_merged(
+                        additional_info, info_to_send
+                    ),
                     fault_tag=fault_tag,
                     symptom=self.symptoms[symptom_id],
                     should_notify=True,
@@ -510,13 +512,41 @@ class FaultManager:
         # Collect all faults mapped from that symptom
         fault: Fault | None = self.found_mapped_fault(symptom_id, sm_name)
 
-        if fault and not any(
+        if not fault:
+            return
+
+        entity_id = "sensor.fault_" + fault.name
+        fault_tag: str = self._generate_fault_tag(fault.name, additional_info)
+        has_active_related_symptoms = any(
             symptom.state == FaultState.SET
             for symptom in self.symptoms.values()
             if symptom.sm_name in set(fault.related_symptoms)
-        ):  # If Fault was found and if other fault related symptoms are not raised
-            # Generate a unique fault tag using the hash method
-            fault_tag: str = self._generate_fault_tag(fault.name, additional_info)
+        )
+
+        if has_active_related_symptoms:
+            info_to_send = self._determinate_info(
+                entity_id, additional_info, FaultState.CLEARED
+            )
+            attributes = info_to_send if info_to_send else {}
+
+            self.hass.set_state(entity_id, state="Set", attributes=attributes)
+
+            if self.event_bus:
+                self.event_bus.publish(
+                    "fault",
+                    fault_name=fault.name,
+                    level=fault.level,
+                    fault_state=FaultState.SET,
+                    additional_info=self._notification_info_from_merged(
+                        additional_info, info_to_send
+                    ),
+                    fault_tag=fault_tag,
+                    symptom=self.symptoms[symptom_id],
+                    should_notify=fault.state == FaultState.SET,
+                )
+            return
+
+        if not has_active_related_symptoms:
             # Save previous value
             fault.previous_val = fault.state
             # Clear Fault
@@ -525,7 +555,7 @@ class FaultManager:
 
             # Determinate additional info
             info_to_send = self._determinate_info(
-                "sensor.fault_" + fault.name, additional_info, FaultState.CLEARED
+                entity_id, additional_info, FaultState.CLEARED
             )
 
             # Prepare the attributes for the state update
@@ -533,7 +563,7 @@ class FaultManager:
 
             # Clear HA entity
             self.hass.set_state(
-                "sensor.fault_" + fault.name, state="Cleared", attributes=attributes
+                entity_id, state="Cleared", attributes=attributes
             )
             self.update_system_state_entity()  # Update the system state entity
 
@@ -698,26 +728,38 @@ class FaultManager:
         self, fault: str, additional_info: Optional[dict] = None
     ) -> str:
         """
-        Generates a unique fault tag by hashing the fault name and additional information.
+        Generates a stable fault tag by hashing the fault name.
 
         Parameters:
             fault: The fault's name.
-            additional_info: Additional information about the fault, such as location.
+            additional_info: Kept for call compatibility; not used for tag identity.
 
         Returns:
-            A unique fault tag as a string.
+            A stable fault tag as a string.
         """
-        # Combine fault name and additional info into a single string
         fault_str = fault
-        if additional_info:
-            # Sort the dictionary items to ensure consistent hash generation
-            sorted_info = sorted(additional_info.items())
-            for key, value in sorted_info:
-                fault_str += f"|{key}:{value}"
-
-        # Generate a hash of the combined string
         fault_hash = hashlib.sha256(fault_str.encode()).hexdigest()
         return fault_hash
+
+    @staticmethod
+    def _notification_info_from_merged(
+        additional_info: Optional[dict], merged_info: Optional[dict]
+    ) -> Optional[dict]:
+        """
+        Build notification details from merged fault attributes.
+
+        Only fields provided by the triggering symptom are sent to notifications,
+        but values are taken from the merged fault state so descriptions reflect
+        all active prefault contributors without leaking Home Assistant metadata.
+        """
+        if not additional_info:
+            return None
+        if not merged_info:
+            return additional_info
+        return {
+            key: merged_info.get(key, value)
+            for key, value in additional_info.items()
+        }
     
     def get_system_fault_level(self) -> int:
         """

--- a/backend/components/faults_manager/fault_manager.py
+++ b/backend/components/faults_manager/fault_manager.py
@@ -30,6 +30,7 @@ import hashlib
 
 from components.core.types_common import FaultState, SMState, Symptom, Fault
 from components.core.event_bus import EventBus
+from components.core.mqtt_entity_manager import MqttEntityManager
 
 
 class FaultManager:
@@ -61,6 +62,7 @@ class FaultManager:
         symptom_dict: dict,
         fault_dict: dict,
         event_bus: EventBus | None = None,
+        mqtt_entities: MqttEntityManager | None = None,
     ) -> None:
         """
         Initialize the Fault Manager.
@@ -76,6 +78,7 @@ class FaultManager:
         self.sm_modules: dict = sm_modules
         self.hass: hass.Hass = hass
         self.event_bus = event_bus
+        self.mqtt_entities = mqtt_entities
 
     def register_callbacks(
         self,
@@ -273,8 +276,8 @@ class FaultManager:
             attributes: dict = info_to_send if info_to_send else {}
 
             # Set HA entity
-            self.hass.set_state(
-                "sensor.fault_" + fault.name, state="Set", attributes=attributes
+            self._set_internal_entity(
+                "sensor.fault_" + fault.name, "Set", attributes
             )
 
             if self.event_bus:
@@ -331,13 +334,10 @@ class FaultManager:
                 return None
 
             # Retrieve the current state object for the entity
-            state = self.hass.get_state(entity_id, attribute="all")
-            # If the entity does not exist, simply return the additional info if the fault is being set
-            if not state:
+            current_attributes = self._get_entity_attributes(entity_id)
+            if not current_attributes:
                 return additional_info if fault_state == FaultState.SET else {}
 
-            # Get the current attributes of the entity; if none exist, initialize to an empty dict
-            current_attributes = state.get("attributes", {})
             if fault_state == FaultState.SET:
                 # Prepare the information to send by merging or updating current attributes with additional info
                 info_to_send = current_attributes.copy()
@@ -455,12 +455,11 @@ class FaultManager:
                 entity_id, additional_info, FaultState.CLEARED
             )
         if info_to_send is None:
-            state = self.hass.get_state(entity_id, attribute="all")
-            attributes = state.get("attributes", {}) if state else {}
+            attributes = self._get_entity_attributes(entity_id)
         else:
             attributes = info_to_send
 
-        self.hass.set_state(entity_id, state="Shadowed", attributes=attributes)
+        self._set_internal_entity(entity_id, "Shadowed", attributes)
 
         if self.event_bus:
             self.event_bus.publish(
@@ -529,7 +528,7 @@ class FaultManager:
             )
             attributes = info_to_send if info_to_send else {}
 
-            self.hass.set_state(entity_id, state="Set", attributes=attributes)
+            self._set_internal_entity(entity_id, "Set", attributes)
 
             if self.event_bus:
                 self.event_bus.publish(
@@ -562,9 +561,7 @@ class FaultManager:
             attributes = info_to_send if info_to_send else {}
 
             # Clear HA entity
-            self.hass.set_state(
-                entity_id, state="Cleared", attributes=attributes
-            )
+            self._set_internal_entity(entity_id, "Cleared", attributes)
             self.update_system_state_entity()  # Update the system state entity
 
             should_notify = fault.previous_val == FaultState.SET
@@ -790,8 +787,30 @@ class FaultManager:
             ),
             "highest_fault_level": highest_fault_level,
         }
-        self.hass.set_state(
-            "sensor.system_state",
-            state=str(highest_fault_level),  # Use the fault level as the state
-            attributes=attributes,
+        self._set_internal_entity(
+            "sensor.safetysystem_state",
+            str(highest_fault_level),
+            attributes,
         )
+
+    def _get_entity_attributes(self, entity_id: str) -> dict:
+        """Return attributes for an internal entity from MQTT state or HA fallback."""
+        if self.mqtt_entities:
+            return self.mqtt_entities.get_attributes(entity_id)
+
+        state = self.hass.get_state(entity_id, attribute="all")
+        if not state:
+            return {}
+        return state.get("attributes", {})
+
+    def _set_internal_entity(
+        self, entity_id: str, state: str, attributes: Optional[dict] = None
+    ) -> None:
+        """Publish an internal entity through MQTT discovery or test fallback."""
+        if self.mqtt_entities:
+            self.mqtt_entities.publish_sensor_state(
+                entity_id, state, attributes=attributes
+            )
+            return
+
+        self.hass.set_state(entity_id, state=state, attributes=attributes or {})

--- a/backend/components/notification_manager/notification_manager.py
+++ b/backend/components/notification_manager/notification_manager.py
@@ -1,14 +1,14 @@
 """
 Notification Manager Module for Home Assistant Safety System
 
-This module contains the NotificationManager class, designed to handle various types of notifications within a Home Assistant-based safety system. It facilitates the delivery of notifications through Home Assistant's notification services, dashboard updates, and other notification mechanisms such as lights and alarms. The NotificationManager is configurable, allowing for dynamic notification behaviors based on the severity of detected faults and system states.
+This module contains the NotificationManager class, designed to handle various types of notifications within a Home Assistant-based safety system. It facilitates the delivery of notifications through Home Assistant's notification services and other notification mechanisms such as lights and alarms. The NotificationManager is configurable, allowing for dynamic notification behaviors based on the severity of detected faults and system states.
 
 The NotificationManager class provides a structured way to manage and execute notifications based on predefined levels of urgency. It maps different notification levels to specific methods that handle the logic for each notification type, ensuring that users are informed of system states and faults in a timely and appropriate manner.
 
 Features include:
 
 Configurable notification levels, allowing for tailored responses to different fault conditions.
-Integration with Home Assistant services for sending notifications to devices, updating dashboard states, and controlling home automation entities like lights and alarms.
+Integration with Home Assistant services for sending notifications to devices and controlling home automation entities like lights and alarms.
 Support for additional information in notifications, enabling detailed fault descriptions to be communicated to the user.
 Use of a unique faulttag to manage notifications effectively, ensuring that notifications related to the same fault instance can be tracked and correlated properly.
 The faulttag feature is utilized to uniquely identify notifications associated with specific fault instances, facilitating efficient management of notification lifecycles, such as setting, updating, and clearing notifications. This ensures that users receive coherent and timely information regarding the status of faults.
@@ -23,14 +23,13 @@ from typing import Optional, Callable
 
 import appdaemon.plugins.hass.hassapi as hass  # type: ignore
 
-from components.core.mqtt_entity_manager import MqttEntityManager
 from components.core.types_common import FaultState
 
 
 class NotificationManager:
     """
     A manager for sending notifications within a Home Assistant-based safety system, using various
-    methods like alerts to mobile devices, dashboard updates, and control of home automation entities
+    methods like alerts to mobile devices and control of home automation entities
     (e.g., lights, alarms) based on event severity.
 
     Attributes:
@@ -46,7 +45,6 @@ class NotificationManager:
         self,
         hass_app: hass.Hass,
         notification_config: dict,
-        mqtt_entities: MqttEntityManager | None = None,
     ):
         """
         Initializes the NotificationManager with Home Assistant and notification configurations.
@@ -57,7 +55,6 @@ class NotificationManager:
         """
         self.hass_app = hass_app
         self.notification_config = notification_config
-        self.mqtt_entities = mqtt_entities
         self.active_notification: dict[str, dict] = {}
 
         # Map notification levels to their respective methods
@@ -155,37 +152,6 @@ class NotificationManager:
 
     def _process_shadowed_fault(self, level: int, fault_tag: str) -> None:
         self._clear_company_app(level, fault_tag)
-
-    def _set_dashboard_notification(self, message: str, level: int) -> None:
-        """
-        Displays a notification message on the Home Assistant dashboard based on severity level.
-
-        Parameters:
-            message: The message to be displayed.
-            level: The message's severity level, influencing its presentation.
-        """
-        # This function assumes that you have an entity in Home Assistant that represents
-        # a text field on a dashboard. You would need to create this entity and configure it
-        # to display messages
-        dashboard_entity = self.notification_config.get(f"dashboard_{level}_entity")
-        if dashboard_entity:
-            if self.mqtt_entities:
-                self.mqtt_entities.register_sensor(
-                    dashboard_entity,
-                    f"Safety Dashboard Level {level}",
-                    icon="mdi:message-alert-outline",
-                )
-                self.mqtt_entities.publish_sensor_state(dashboard_entity, message)
-            else:
-                self.hass_app.set_state(dashboard_entity, state=message)
-            self.hass_app.log(
-                f"Dashboard entity {dashboard_entity} was changed to {message}",
-                level="DEBUG",
-            )
-        else:
-            self.hass_app.log(
-                f"No dashboard entity configured for level '{level}'", level="WARNING"
-            )
 
     def _notify_level_1_additional(self) -> None:
         """

--- a/backend/components/notification_manager/notification_manager.py
+++ b/backend/components/notification_manager/notification_manager.py
@@ -23,6 +23,7 @@ from typing import Optional, Callable
 
 import appdaemon.plugins.hass.hassapi as hass  # type: ignore
 
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.core.types_common import FaultState
 
 
@@ -41,7 +42,12 @@ class NotificationManager:
         notification_config (dict): Configuration for different notification levels and entities.
     """
 
-    def __init__(self, hass_app: hass.Hass, notification_config: dict):
+    def __init__(
+        self,
+        hass_app: hass.Hass,
+        notification_config: dict,
+        mqtt_entities: MqttEntityManager | None = None,
+    ):
         """
         Initializes the NotificationManager with Home Assistant and notification configurations.
 
@@ -51,6 +57,7 @@ class NotificationManager:
         """
         self.hass_app = hass_app
         self.notification_config = notification_config
+        self.mqtt_entities = mqtt_entities
         self.active_notification: dict[str, dict] = {}
 
         # Map notification levels to their respective methods
@@ -162,7 +169,15 @@ class NotificationManager:
         # to display messages
         dashboard_entity = self.notification_config.get(f"dashboard_{level}_entity")
         if dashboard_entity:
-            self.hass_app.set_state(dashboard_entity, state=message)
+            if self.mqtt_entities:
+                self.mqtt_entities.register_sensor(
+                    dashboard_entity,
+                    f"Safety Dashboard Level {level}",
+                    icon="mdi:message-alert-outline",
+                )
+                self.mqtt_entities.publish_sensor_state(dashboard_entity, message)
+            else:
+                self.hass_app.set_state(dashboard_entity, state=message)
             self.hass_app.log(
                 f"Dashboard entity {dashboard_entity} was changed to {message}",
                 level="DEBUG",

--- a/backend/components/notification_manager/schema.py
+++ b/backend/components/notification_manager/schema.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any, Callable, Optional
 
-from pydantic import ConfigDict, ValidationError, field_validator
+from pydantic import ConfigDict, ValidationError
 
 from components.core.pydantic_utils import StrictBaseModel, log_extra_keys
 
@@ -17,26 +16,6 @@ class NotificationConfig(StrictBaseModel):
 
     light_entity: Optional[str] = None
     alarm_entity: Optional[str] = None
-    dashboard_1_entity: Optional[str] = None
-    dashboard_2_entity: Optional[str] = None
-    dashboard_3_entity: Optional[str] = None
-    dashboard_4_entity: Optional[str] = None
-
-    @field_validator(
-        "dashboard_1_entity",
-        "dashboard_2_entity",
-        "dashboard_3_entity",
-        "dashboard_4_entity",
-    )
-    @classmethod
-    def _validate_dashboard_sensor(cls, value: str | None) -> str | None:
-        if value is not None and not re.fullmatch(
-            r"sensor\.[a-z0-9_]+", value
-        ):
-            raise ValueError(
-                "dashboard notification entity must be a valid sensor entity_id"
-            )
-        return value
 
 
 def validate_notification_config(

--- a/backend/components/notification_manager/schema.py
+++ b/backend/components/notification_manager/schema.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Optional
 
-from pydantic import ConfigDict, ValidationError
+from pydantic import ConfigDict, ValidationError, field_validator
 
 from components.core.pydantic_utils import StrictBaseModel, log_extra_keys
 
@@ -20,6 +21,22 @@ class NotificationConfig(StrictBaseModel):
     dashboard_2_entity: Optional[str] = None
     dashboard_3_entity: Optional[str] = None
     dashboard_4_entity: Optional[str] = None
+
+    @field_validator(
+        "dashboard_1_entity",
+        "dashboard_2_entity",
+        "dashboard_3_entity",
+        "dashboard_4_entity",
+    )
+    @classmethod
+    def _validate_dashboard_sensor(cls, value: str | None) -> str | None:
+        if value is not None and not re.fullmatch(
+            r"sensor\.[a-z0-9_]+", value
+        ):
+            raise ValueError(
+                "dashboard notification entity must be a valid sensor entity_id"
+            )
+        return value
 
 
 def validate_notification_config(

--- a/backend/components/recovery_manager/recovery_manager.py
+++ b/backend/components/recovery_manager/recovery_manager.py
@@ -68,7 +68,7 @@ class RecoveryManager:
         recovery_actions: dict,
         common_entities: CommonEntities,
         nm: NotificationManager,
-        mqtt_entities: MqttEntityManager | None = None,
+        mqtt_entities: MqttEntityManager,
     ) -> None:
         """
         Initializes the RecoveryManager with the necessary application context and recovery configuration.
@@ -274,16 +274,16 @@ class RecoveryManager:
             sensor_name, expected_domain="sensor"
         )
         sensor_value: str = str(recovery.current_status.name)
-        if self.mqtt_entities:
-            self.mqtt_entities.register_sensor(
-                sensor_name,
-                f"Recovery {recovery.name}",
-                icon="mdi:lifebuoy",
-            )
-            self.mqtt_entities.publish_sensor_state(sensor_name, sensor_value)
-            return
-
-        self.hass_app.set_state(sensor_name, state=sensor_value)
+        self.mqtt_entities.register_sensor(
+            sensor_name,
+            f"Recovery {recovery.name}",
+            attributes={
+                "description": f"Recovery status for {recovery.name}.",
+            },
+            icon="mdi:lifebuoy",
+            entity_category="diagnostic",
+        )
+        self.mqtt_entities.publish_sensor_state(sensor_name, sensor_value)
 
     def _execute_entity_action(self, entity: str, value: str) -> None:
         """Execute a supported recovery action through a native HA service."""

--- a/backend/components/recovery_manager/recovery_manager.py
+++ b/backend/components/recovery_manager/recovery_manager.py
@@ -20,22 +20,30 @@ logic within callable functions and associating them with particular fault condi
 This module's approach to fault recovery empowers developers to construct robust and adaptable safety mechanisms, enhancing the resilience and reliability of automated systems. The faulttag feature helps uniquely identify each fault scenario, aiding in efficient fault resolution and ensuring accurate system state tracking throughout the recovery process.
 """
 
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 import appdaemon.plugins.hass.hassapi as hass  # type: ignore
 
 from components.core.common_entities import CommonEntities
-from components.faults_manager.fault_manager import FaultManager
-from components.notification_manager.notification_manager import NotificationManager
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.core.types_common import (
-    RecoveryAction,
-    Symptom,
-    SMState,
-    FaultState,
     Fault,
+    FaultState,
+    RecoveryAction,
     RecoveryActionState,
     RecoveryResult,
+    SMState,
+    Symptom,
 )
+from components.faults_manager.fault_manager import FaultManager
+from components.notification_manager.notification_manager import NotificationManager
+
+
+_TOGGLE_SERVICE_DOMAINS = frozenset(
+    {"fan", "input_boolean", "light", "siren", "switch"}
+)
+_COVER_OPEN_VALUES = frozenset({"on", "open", "opened"})
+_COVER_CLOSE_VALUES = frozenset({"off", "close", "closed"})
 
 
 class RecoveryManager:
@@ -60,6 +68,7 @@ class RecoveryManager:
         recovery_actions: dict,
         common_entities: CommonEntities,
         nm: NotificationManager,
+        mqtt_entities: MqttEntityManager | None = None,
     ) -> None:
         """
         Initializes the RecoveryManager with the necessary application context and recovery configuration.
@@ -87,6 +96,9 @@ class RecoveryManager:
         self.common_entities: CommonEntities = common_entities
         self.fm: FaultManager = fm
         self.nm: NotificationManager = nm
+        self.mqtt_entities = mqtt_entities
+        self._pending_recovery_confirmations: dict[str, dict[str, str]] = {}
+        self._recovery_confirmation_handles: dict[str, list[Any]] = {}
 
         self._init_all_rec_entities()
 
@@ -185,7 +197,7 @@ class RecoveryManager:
         notifications: list,
         entities_changes: dict[str, str],
         fault_tag: str,
-    ) -> None:
+    ) -> dict[str, str]:
         """
         Executes the recovery actions for the given symptom, including notifications and entity changes.
 
@@ -194,18 +206,22 @@ class RecoveryManager:
         to system entities to resolve the fault condition.
 
         Args:
-            symptom (symptom): The symptom object representing the fault to recover from.
+            symptom (Symptom): The symptom object representing the fault to recover from.
             notifications (list): A list of notifications to send as part of the recovery process.
             entities_changes (dict[str, str]): A dictionary mapping entity names to their new values as part of the recovery process.
+
+        Returns:
+            dict[str, str]: Actuator commands accepted by Home Assistant.
         """
+        executed_changes: dict[str, str] = {}
         rec: RecoveryAction | None = self._find_recovery(symptom.name)
         if rec:
             rec.current_status = RecoveryActionState.TO_PERFORM
             self._set_rec_entity(rec)
-            # Set entitity actions as recovery
             for entity, value in entities_changes.items():
                 try:
-                    self.hass_app.set_state(entity, state=value)
+                    self._execute_entity_action(entity, value)
+                    executed_changes[entity] = value
                 except Exception as err:
                     self.hass_app.log(
                         f"Exception during setting {entity} to {value} value. {err}",
@@ -221,6 +237,7 @@ class RecoveryManager:
             self.hass_app.log(
                 f"Recovery action for {symptom.name} was not found!", level="ERROR"
             )
+        return executed_changes
 
     def _find_recovery(self, symptom_name: str) -> RecoveryAction | None:
         """
@@ -252,9 +269,62 @@ class RecoveryManager:
         Args:
             recovery (RecoveryAction): The recovery action to set the state for.
         """
-        sensor_name: str = f"sensor.recovery_{recovery.name}".lower()
+        sensor_name = f"sensor.recovery_{recovery.name}"
+        sensor_name = MqttEntityManager.canonical_entity_id(
+            sensor_name, expected_domain="sensor"
+        )
         sensor_value: str = str(recovery.current_status.name)
+        if self.mqtt_entities:
+            self.mqtt_entities.register_sensor(
+                sensor_name,
+                f"Recovery {recovery.name}",
+                icon="mdi:lifebuoy",
+            )
+            self.mqtt_entities.publish_sensor_state(sensor_name, sensor_value)
+            return
+
         self.hass_app.set_state(sensor_name, state=sensor_value)
+
+    def _execute_entity_action(self, entity: str, value: str) -> None:
+        """Execute a supported recovery action through a native HA service."""
+        service = self._resolve_entity_action(entity, value)
+        response = self.hass_app.call_service(service, entity_id=entity)
+        if isinstance(response, Mapping) and response.get("success") is False:
+            raise RuntimeError(
+                f"Home Assistant service {service} rejected {entity}: {response}"
+            )
+
+    @staticmethod
+    def _resolve_entity_action(entity: str, value: str) -> str:
+        """Resolve a constrained entity/value pair to a Home Assistant service."""
+        if not isinstance(entity, str) or entity.count(".") != 1:
+            raise ValueError(f"Invalid recovery entity_id: {entity!r}")
+        domain, object_id = entity.split(".", 1)
+        if not domain or not object_id:
+            raise ValueError(f"Invalid recovery entity_id: {entity!r}")
+
+        normalized_value = str(value).strip().lower()
+        if domain == "cover":
+            if normalized_value in _COVER_OPEN_VALUES:
+                return "cover/open_cover"
+            if normalized_value in _COVER_CLOSE_VALUES:
+                return "cover/close_cover"
+            raise ValueError(
+                f"Unsupported cover target {value!r} for recovery entity {entity}"
+            )
+
+        if domain in _TOGGLE_SERVICE_DOMAINS:
+            if normalized_value == "on":
+                return f"{domain}/turn_on"
+            if normalized_value == "off":
+                return f"{domain}/turn_off"
+            raise ValueError(
+                f"Unsupported {domain} target {value!r} for recovery entity {entity}"
+            )
+
+        raise ValueError(
+            f"Unsupported recovery domain {domain!r} for entity {entity}"
+        )
 
     def _is_dry_test_failed(
         self, prefaul_name: str, entities_changes: dict[str, str]
@@ -416,7 +486,7 @@ class RecoveryManager:
         self.hass_app.log(
             f"Executing recovery for symptom: {symptom.name}", level="DEBUG"
         )
-        self._perform_recovery(
+        executed_actuator_changes = self._perform_recovery(
             symptom,
             recovery_result.notifications,
             recovery_result.changed_actuators,
@@ -428,7 +498,8 @@ class RecoveryManager:
         )
         self._listen_to_changes(
             symptom,
-            recovery_result.changed_sensors | recovery_result.changed_actuators,
+            recovery_result.changed_sensors,
+            executed_actuator_changes,
         )
         self.hass_app.log(f"Listeners set for symptom: {symptom.name}", level="DEBUG")
 
@@ -444,6 +515,8 @@ class RecoveryManager:
             symptom (symptom): The symptom object representing the fault to clear the recovery action for.
         """
         if symptom.name in self.recovery_actions:
+            self._cancel_recovery_confirmation_listeners(symptom.name)
+            self._pending_recovery_confirmations.pop(symptom.name, None)
             # Clear internal register
             self.recovery_actions[symptom.name].current_status = (
                 RecoveryActionState.DO_NOT_PERFORM
@@ -451,7 +524,12 @@ class RecoveryManager:
             # Set HA entity
             self._set_rec_entity(self.recovery_actions[symptom.name])
 
-    def _listen_to_changes(self, symptom: Symptom, entities_changes: dict) -> None:
+    def _listen_to_changes(
+        self,
+        symptom: Symptom,
+        sensor_changes: dict[str, str],
+        actuator_changes: dict[str, str],
+    ) -> None:
         """
         Sets up listeners for state changes in the specified entities to monitor recovery action completion.
 
@@ -461,13 +539,80 @@ class RecoveryManager:
 
         Args:
             symptom (symptom): The symptom object representing the fault being recovered from.
-            entities_changes (dict): A dictionary mapping entity names to their new values to monitor.
+            sensor_changes (dict[str, str]): Physical postconditions to monitor.
+            actuator_changes (dict[str, str]): Successfully requested actuators,
+                used only when no dedicated postcondition sensor exists.
         """
-        for name in entities_changes:
-            self.hass_app.listen_state(self._recovery_performed, name, symptom=symptom)
+        expected_changes = dict(sensor_changes)
+        if not expected_changes:
+            expected_changes = self._actuator_postconditions(actuator_changes)
+
+        if not expected_changes:
+            self.hass_app.log(
+                f"No observable postcondition for recovery {symptom.name}.",
+                level="WARNING",
+            )
+            return
+
+        self._cancel_recovery_confirmation_listeners(symptom.name)
+        self._pending_recovery_confirmations[symptom.name] = {
+            entity_id: str(expected_state)
+            for entity_id, expected_state in expected_changes.items()
+        }
+        handles: list[Any] = []
+        self._recovery_confirmation_handles[symptom.name] = handles
+        for entity_id, expected_state in expected_changes.items():
+            handle = self.hass_app.listen_state(
+                self._recovery_performed,
+                entity_id,
+                new=str(expected_state),
+                symptom=symptom,
+                confirmation_entity=entity_id,
+                expected_state=str(expected_state),
+            )
+            handles.append(handle)
+
+        if self._all_recovery_postconditions_met(symptom.name):
+            self._recovery_clear(symptom)
+
+    def _cancel_recovery_confirmation_listeners(self, symptom_name: str) -> None:
+        """Cancel state listeners left by a completed or superseded recovery."""
+        handles = self._recovery_confirmation_handles.pop(symptom_name, [])
+        cancel_listener = getattr(self.hass_app, "cancel_listen_state", None)
+        if cancel_listener is None:
+            return
+        for handle in handles:
+            try:
+                cancel_listener(handle)
+            except Exception as exc:
+                self.hass_app.log(
+                    f"Failed to cancel recovery listener: {exc}",
+                    level="WARNING",
+                )
+
+    @staticmethod
+    def _actuator_postconditions(
+        actuator_changes: dict[str, str],
+    ) -> dict[str, str]:
+        """Translate actuator commands into observable fallback states."""
+        expected_states: dict[str, str] = {}
+        for entity_id, value in actuator_changes.items():
+            domain = entity_id.split(".", 1)[0] if "." in entity_id else ""
+            normalized_value = str(value).strip().lower()
+            if domain == "cover":
+                if normalized_value in _COVER_OPEN_VALUES:
+                    expected_states[entity_id] = "open"
+                elif normalized_value in _COVER_CLOSE_VALUES:
+                    expected_states[entity_id] = "closed"
+            elif domain in _TOGGLE_SERVICE_DOMAINS and normalized_value in {
+                "on",
+                "off",
+            }:
+                expected_states[entity_id] = normalized_value
+        return expected_states
 
     def _recovery_performed(
-        self, _: Any, __: Any, ___: Any, ____: Any, cb_args: dict
+        self, _: Any, __: Any, ___: Any, new: Any, **cb_args: Any
     ) -> None:
         """
         Callback function invoked when a recovery action is performed.
@@ -481,6 +626,32 @@ class RecoveryManager:
             __ (Any): Placeholder for the second callback argument (not used).
             ___ (Any): Placeholder for the third callback argument (not used).
             ____ (Any): Placeholder for the fourth callback argument (not used).
-            cb_args (dict): A dictionary containing callback arguments, including the symptom to clear.
+            **cb_args (Any): AppDaemon callback arguments, including the symptom
+                and expected confirmation state.
         """
-        self._recovery_clear(cb_args["symptom"])
+        symptom: Symptom = cb_args["symptom"]
+        expected_state = cb_args["expected_state"]
+        if str(new) != expected_state:
+            return
+
+        expected_changes = self._pending_recovery_confirmations.get(symptom.name)
+        if expected_changes is None:
+            return
+        confirmation_entity = cb_args["confirmation_entity"]
+        if expected_changes.get(confirmation_entity) != expected_state:
+            return
+
+        if self._all_recovery_postconditions_met(symptom.name):
+            self._recovery_clear(symptom)
+
+    def _all_recovery_postconditions_met(self, symptom_name: str) -> bool:
+        """Return whether all current recovery postconditions are satisfied."""
+        expected_changes = self._pending_recovery_confirmations.get(symptom_name)
+        if not expected_changes:
+            return False
+
+        for entity_id, current_expected_state in expected_changes.items():
+            current_state = self.hass_app.get_state(entity_id)
+            if str(current_state) != current_expected_state:
+                return False
+        return True

--- a/backend/components/safetycomponents/core/safety_component.py
+++ b/backend/components/safetycomponents/core/safety_component.py
@@ -22,6 +22,7 @@ A developer might create a `TemperatureSafetyComponent` subclass that monitors t
 This module streamlines the creation of safety mechanisms, emphasizing reliability, flexibility, and integration with Home Assistant's dynamic ecosystem.
 """
 
+from collections.abc import Iterable
 from typing import (
     Type,
     Any,
@@ -312,9 +313,12 @@ class SafetyComponent:
             return None
 
     @staticmethod
-    def change_all_entities_state(entities: list[str], state: str) -> dict[str, str]:
-        """Create a dictionary to change the state of entities."""
-        return {entity: state for entity in [entities]}  # type: ignore
+    def change_all_entities_state(
+        entities: str | Iterable[str], state: str
+    ) -> dict[str, str]:
+        """Map one entity or an iterable of entities to an expected state."""
+        entity_ids = [entities] if isinstance(entities, str) else list(entities)
+        return {entity_id: state for entity_id in entity_ids}
 
     def _debounce(
         self, current_counter: int, pr_test: bool, debounce_limit: int = 3

--- a/backend/components/safetycomponents/core/safety_component.py
+++ b/backend/components/safetycomponents/core/safety_component.py
@@ -41,6 +41,7 @@ import appdaemon.plugins.hass.hassapi as hass  # type: ignore
 from components.core.common_entities import CommonEntities
 from components.core.derivative_monitor import DerivativeMonitor
 from components.core.event_bus import EventBus
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.core.types_common import FaultState, Symptom, RecoveryAction, SMState
 
 NO_NEEDED = False
@@ -145,6 +146,7 @@ class SafetyComponent:
         hass_app: hass.Hass,
         common_entities: CommonEntities,
         event_bus: EventBus,
+        mqtt_entities: MqttEntityManager,
     ) -> None:
         """
         Initialize the safety component.
@@ -156,7 +158,7 @@ class SafetyComponent:
         self.event_bus: EventBus = event_bus
         self.symptom_states: dict[str, FaultState] = {}
         self.init_common_data()
-        self.derivative_monitor = DerivativeMonitor(hass_app)
+        self.derivative_monitor = DerivativeMonitor(hass_app, mqtt_entities)
 
     def init_common_data(self) -> None:
         # Initialize dictionaries that need to be unique to each instance

--- a/backend/components/safetycomponents/temperature/schema.py
+++ b/backend/components/safetycomponents/temperature/schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Optional
 
-from pydantic import ConfigDict, ValidationError, model_validator
+from pydantic import ConfigDict, ValidationError, field_validator, model_validator
 
 from components.core.pydantic_utils import StrictBaseModel, log_extra_keys
 
@@ -32,6 +32,15 @@ class TemperatureRoom(StrictBaseModel):
     CAL_LOW_TEMP_THRESHOLD: Optional[float] = None
     CAL_HIGH_TEMP_THRESHOLD: Optional[float] = None
     CAL_FORECAST_TIMESPAN: Optional[float] = None
+
+    @field_validator("actuator")
+    @classmethod
+    def _validate_window_actuator(cls, value: str | None) -> str | None:
+        if value is not None and not value.startswith("cover."):
+            raise ValueError(
+                "TemperatureComponent actuator must be a cover entity"
+            )
+        return value
 
     @model_validator(mode="after")
     def _ensure_thresholds_present(self) -> "TemperatureRoom":

--- a/backend/components/safetycomponents/temperature/schema.py
+++ b/backend/components/safetycomponents/temperature/schema.py
@@ -28,6 +28,7 @@ class TemperatureRoom(StrictBaseModel):
 
     temperature_sensor: str
     window_sensor: Optional[str] = None
+    actuator: Optional[str] = None
     CAL_LOW_TEMP_THRESHOLD: Optional[float] = None
     CAL_HIGH_TEMP_THRESHOLD: Optional[float] = None
     CAL_FORECAST_TIMESPAN: Optional[float] = None
@@ -55,6 +56,7 @@ class TemperatureRoom(StrictBaseModel):
         merged: Dict[str, Any] = {
             "temperature_sensor": self.temperature_sensor,
             "window_sensor": self.window_sensor,
+            "actuator": self.actuator,
         }
 
         low_temp = (

--- a/backend/components/safetycomponents/temperature/temperature_component.py
+++ b/backend/components/safetycomponents/temperature/temperature_component.py
@@ -26,6 +26,7 @@ from typing import Dict, Any, Callable, Optional
 import appdaemon.plugins.hass.hassapi as hass  # type: ignore
 
 from components.core.common_entities import CommonEntities
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.safetycomponents.core.safety_component import (
     SafetyComponent,
     safety_mechanism_decorator,
@@ -60,6 +61,7 @@ class TemperatureComponent(SafetyComponent):
         hass_app: hass,
         common_entities: CommonEntities,
         event_bus: Any,
+        mqtt_entities: MqttEntityManager,
     ) -> None:  # type: ignore
         """
         Initializes the TemperatureComponent instance with the Home Assistant application context, setting up the foundation
@@ -69,7 +71,7 @@ class TemperatureComponent(SafetyComponent):
             hass_app (hass.Hass): The Home Assistant application instance through which sensor data is accessed and actions are executed.
             common_entities (CommonEntities): A shared object providing access to common entities used across different safety mechanisms.
         """
-        super().__init__(hass_app, common_entities, event_bus)
+        super().__init__(hass_app, common_entities, event_bus, mqtt_entities)
 
     def get_symptoms_data(
         self, sm_modules: dict, component_cfg: list[dict[str, Any]]

--- a/backend/tests/appdaemon/plugins/hass/hassapi.py
+++ b/backend/tests/appdaemon/plugins/hass/hassapi.py
@@ -89,3 +89,6 @@ class Hass:
 
     def cancel_timer(self, handle: Any) -> None:
         return None
+
+    def cancel_listen_state(self, handle: Any) -> None:
+        return None

--- a/backend/tests/appdaemon/plugins/hass/hassapi.py
+++ b/backend/tests/appdaemon/plugins/hass/hassapi.py
@@ -46,6 +46,7 @@ class Hass:
         self.get_state = getattr(ad, "get_state", self.get_state)  # type: ignore
         self.call_service = getattr(ad, "call_service", self.call_service)  # type: ignore
         self.run_in = getattr(ad, "run_in", self.run_in)  # type: ignore
+        self.run_every = getattr(ad, "run_every", self.run_every)  # type: ignore
         self.listen_state = getattr(ad, "listen_state", self.listen_state)  # type: ignore
 
     def log(self, msg: str, *args: Any, **kwargs: Any) -> None:
@@ -71,6 +72,16 @@ class Hass:
     def run_in(self, callback: Callable, delay: int, **kwargs: Any) -> Any:
         # In test mode, immediately execute the callback to keep behavior predictable
         return callback(**kwargs)
+
+    def run_every(
+        self,
+        callback: Callable,
+        start: Any,
+        interval: int,
+        **kwargs: Any,
+    ) -> Any:
+        # Return a dummy timer handle; periodic execution is driven explicitly in tests.
+        return (callback, start, interval, kwargs)
 
     def listen_state(self, callback: Callable, entity: str, **kwargs: Any) -> Any:
         # Return a dummy handle for cancellation in potential future extensions

--- a/backend/tests/fixtures/hass_fixture.py
+++ b/backend/tests/fixtures/hass_fixture.py
@@ -18,6 +18,7 @@ def mocked_hass() -> Generator[Any, Any, None]:
         mock_hass.set_state = MagicMock()
         mock_hass.call_service = MagicMock()
         mock_hass.run_in = MagicMock()
+        mock_hass.run_every = MagicMock()
         mock_hass.listen_state = MagicMock()
         yield mock_hass
 
@@ -47,6 +48,7 @@ def mocked_hass_app_basic(mocked_hass, app_config_valid):
         app_instance.set_state = mocked_hass.set_state
         app_instance.call_service = mocked_hass.call_service
         app_instance.run_in = mocked_hass.run_in
+        app_instance.run_every = mocked_hass.run_every
         app_instance.listen_state = mocked_hass.listen_state
         yield app_instance, mocked_hass, mock_log_method
 
@@ -80,6 +82,7 @@ def mocked_hass_app_with_temp_component(mocked_hass, app_config_valid):
         app_instance.set_state = mocked_hass.set_state
         app_instance.call_service = mocked_hass.call_service
         app_instance.run_in = mocked_hass.run_in
+        app_instance.run_every = mocked_hass.run_every
         app_instance.listen_state = mocked_hass.listen_state
 
         yield app_instance, mocked_hass, mock_log_method, MockTemperatureComponent, mock_behaviors

--- a/backend/tests/fixtures/hass_fixture.py
+++ b/backend/tests/fixtures/hass_fixture.py
@@ -1,10 +1,12 @@
 from itertools import cycle
+import json
 from typing import Any, Generator, List
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from SafetyFunctions import SafetyFunctions
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.safetycomponents.temperature.temperature_component import TemperatureComponent
 
 
@@ -146,3 +148,31 @@ def update_mocked_get_state(default: List[MockBehavior], test_specyfic: List[Moc
             default.append(test_mock)
 
     return default
+
+
+def mqtt_topic_for(entity_id: str, topic_kind: str = "state") -> str:
+    """Return the default SafetyFunctions MQTT topic for an entity."""
+    object_id = MqttEntityManager._slug(entity_id.split(".", 1)[-1])
+    return f"safety_component/{topic_kind}/{object_id}"
+
+
+def mqtt_publish_calls(hass_app: Any, topic: str | None = None) -> list[Any]:
+    """Return mqtt.publish service calls, optionally filtered by topic."""
+    calls = [
+        call
+        for call in hass_app.call_service.call_args_list
+        if call.args and call.args[0] == "mqtt/publish"
+    ]
+    if topic is None:
+        return calls
+    return [call for call in calls if call.kwargs.get("topic") == topic]
+
+
+def mqtt_payloads(hass_app: Any, topic: str) -> list[str]:
+    """Return MQTT payloads published to a topic."""
+    return [call.kwargs["payload"] for call in mqtt_publish_calls(hass_app, topic)]
+
+
+def mqtt_json_payloads(hass_app: Any, topic: str) -> list[dict[str, Any]]:
+    """Return JSON MQTT payloads published to a topic."""
+    return [json.loads(payload) for payload in mqtt_payloads(hass_app, topic)]

--- a/backend/tests/test_app_cfg_validator.py
+++ b/backend/tests/test_app_cfg_validator.py
@@ -32,6 +32,37 @@ def test_validate_app_cfg_filters_disabled_components(app_config_valid):
     assert "TemperatureComponent" not in validated["user_config"]["safety_components"]
 
 
+def test_validate_app_cfg_applies_safe_mqtt_defaults(app_config_valid):
+    validated = AppCfgValidator.validate(app_config_valid)
+
+    mqtt_config = validated["user_config"]["mqtt"]
+    assert mqtt_config["retain_discovery"] is True
+    assert mqtt_config["retain_state"] is False
+    assert mqtt_config["availability_topic"] == "safety_component/status"
+    assert mqtt_config["heartbeat_seconds"] == 60
+    assert mqtt_config["expire_after"] == 180
+
+
+@pytest.mark.parametrize(
+    "mqtt_config",
+    [
+        {"qos": 4},
+        {"retain_discovery": False},
+        {"base_topic": "safety/#"},
+        {"retain_state": "false"},
+        {"heartbeat_seconds": 0, "expire_after": 180},
+    ],
+)
+def test_validate_app_cfg_rejects_invalid_mqtt_settings(
+    app_config_valid, mqtt_config
+):
+    cfg = copy.deepcopy(app_config_valid)
+    cfg["user_config"]["mqtt"] = mqtt_config
+
+    with pytest.raises(AppCfgValidationError):
+        AppCfgValidator.validate(cfg)
+
+
 def test_validate_app_cfg_requires_thresholds(app_config_valid):
     cfg = copy.deepcopy(app_config_valid)
     component_cfg = cfg["user_config"]["safety_components"]["TemperatureComponent"]
@@ -40,6 +71,60 @@ def test_validate_app_cfg_requires_thresholds(app_config_valid):
     component_cfg["rooms"]["Office"].pop("CAL_FORECAST_TIMESPAN")
 
     with pytest.raises(AppCfgValidationError):
+        AppCfgValidator.validate(cfg)
+
+
+def test_validate_app_cfg_rejects_non_cover_temperature_actuator(
+    app_config_valid,
+):
+    cfg = copy.deepcopy(app_config_valid)
+    cfg["user_config"]["safety_components"]["TemperatureComponent"]["rooms"][
+        "Office"
+    ]["actuator"] = "switch.window_relay"
+
+    with pytest.raises(AppCfgValidationError, match="cover entity"):
+        AppCfgValidator.validate(cfg)
+
+
+def test_validate_app_cfg_treats_dashboard_sensor_as_mqtt_output(
+    app_config_valid,
+):
+    cfg = copy.deepcopy(app_config_valid)
+    cfg["app_config"]["validation"]["validate_entity_existence"] = True
+    cfg["user_config"]["notification"][
+        "dashboard_1_entity"
+    ] = "sensor.safety_dashboard_emergency"
+
+    class ExistingDependenciesHass:
+        def get_state(self, entity_id):
+            if entity_id == "sensor.safety_dashboard_emergency":
+                return None
+            return "available"
+
+    validated = AppCfgValidator.validate(cfg, hass=ExistingDependenciesHass())
+
+    assert (
+        validated["user_config"]["notification"]["dashboard_1_entity"]
+        == "sensor.safety_dashboard_emergency"
+    )
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "text.safety_dashboard_emergency",
+        "sensor.",
+        "sensor.foo.bar",
+        "sensor.Invalid",
+    ],
+)
+def test_validate_app_cfg_rejects_invalid_dashboard_output(
+    app_config_valid, entity_id
+):
+    cfg = copy.deepcopy(app_config_valid)
+    cfg["user_config"]["notification"]["dashboard_1_entity"] = entity_id
+
+    with pytest.raises(AppCfgValidationError, match="valid sensor entity_id"):
         AppCfgValidator.validate(cfg)
 
 

--- a/backend/tests/test_app_cfg_validator.py
+++ b/backend/tests/test_app_cfg_validator.py
@@ -23,13 +23,17 @@ def test_validate_app_cfg_normalizes_temperature_component(app_config_valid):
     assert office_cfg["CAL_FORECAST_TIMESPAN"] == 2.0
 
 
-def test_validate_app_cfg_filters_disabled_components(app_config_valid):
+def test_validate_app_cfg_rejects_configuration_without_enabled_components(
+    app_config_valid,
+):
     cfg = copy.deepcopy(app_config_valid)
     cfg["user_config"]["components_enabled"]["TemperatureComponent"] = False
 
-    validated = AppCfgValidator.validate(cfg)
-
-    assert "TemperatureComponent" not in validated["user_config"]["safety_components"]
+    with pytest.raises(
+        AppCfgValidationError,
+        match="must enable at least one component",
+    ):
+        AppCfgValidator.validate(cfg)
 
 
 def test_validate_app_cfg_applies_safe_mqtt_defaults(app_config_valid):
@@ -86,45 +90,15 @@ def test_validate_app_cfg_rejects_non_cover_temperature_actuator(
         AppCfgValidator.validate(cfg)
 
 
-def test_validate_app_cfg_treats_dashboard_sensor_as_mqtt_output(
+def test_validate_app_cfg_rejects_removed_dashboard_notification_config(
     app_config_valid,
 ):
     cfg = copy.deepcopy(app_config_valid)
-    cfg["app_config"]["validation"]["validate_entity_existence"] = True
     cfg["user_config"]["notification"][
         "dashboard_1_entity"
     ] = "sensor.safety_dashboard_emergency"
 
-    class ExistingDependenciesHass:
-        def get_state(self, entity_id):
-            if entity_id == "sensor.safety_dashboard_emergency":
-                return None
-            return "available"
-
-    validated = AppCfgValidator.validate(cfg, hass=ExistingDependenciesHass())
-
-    assert (
-        validated["user_config"]["notification"]["dashboard_1_entity"]
-        == "sensor.safety_dashboard_emergency"
-    )
-
-
-@pytest.mark.parametrize(
-    "entity_id",
-    [
-        "text.safety_dashboard_emergency",
-        "sensor.",
-        "sensor.foo.bar",
-        "sensor.Invalid",
-    ],
-)
-def test_validate_app_cfg_rejects_invalid_dashboard_output(
-    app_config_valid, entity_id
-):
-    cfg = copy.deepcopy(app_config_valid)
-    cfg["user_config"]["notification"]["dashboard_1_entity"] = entity_id
-
-    with pytest.raises(AppCfgValidationError, match="valid sensor entity_id"):
+    with pytest.raises(AppCfgValidationError, match="Unknown keys.*dashboard_1_entity"):
         AppCfgValidator.validate(cfg)
 
 

--- a/backend/tests/test_derivative_monitor.py
+++ b/backend/tests/test_derivative_monitor.py
@@ -1,121 +1,126 @@
-import pytest
 from unittest.mock import Mock, call
+
+import pytest
+
 from components.core.derivative_monitor import DerivativeMonitor
 
 
 @pytest.fixture
 def setup_derivative_monitor():
-    """Fixture to set up a mock Hass app and a fresh DerivativeMonitor instance."""
+    """Set up a fresh derivative monitor with an MQTT publisher."""
     mock_hass = Mock()
     mock_hass.run_every = Mock()
+    mqtt_entities = Mock()
     DerivativeMonitor._instance = None
-    derivative_monitor = DerivativeMonitor(mock_hass)
+    derivative_monitor = DerivativeMonitor(mock_hass, mqtt_entities)
 
-    # Ensure singleton state is clean for each test
     derivative_monitor.entities.clear()
     derivative_monitor.derivative_data.clear()
-
-    # Use a mutable dictionary to hold state values (ensures proper scoping in closures)
     state_values = {}
 
     def mock_get_state(entity_id, **kwargs):
-        return state_values.get(entity_id, None)
+        return state_values.get(entity_id)
 
     def set_mock_state(entity_id, value):
         state_values[entity_id] = value
 
-    # Attach state change simulation to mock_hass
     mock_hass.get_state.side_effect = mock_get_state
-    mock_hass.set_state.side_effect = lambda entity_id, state, **kwargs: set_mock_state(
-        entity_id, state
-    )
-
-    return mock_hass, derivative_monitor, set_mock_state
+    return mock_hass, mqtt_entities, derivative_monitor, set_mock_state
 
 
 def test_register_entity(setup_derivative_monitor):
-    """Verify entity registration and creation of derivative entities in Home Assistant."""
-    mock_hass, derivative_monitor, _ = setup_derivative_monitor
+    """Verify derivative sensors are registered through MQTT discovery."""
+    mock_hass, mqtt_entities, derivative_monitor, _ = setup_derivative_monitor
     entity_id = "sensor.temperature"
     sample_time = 10
-    low_saturation = -5.0
-    high_saturation = 5.0
 
-    derivative_monitor.register_entity(entity_id, sample_time, low_saturation, high_saturation)
+    derivative_monitor.register_entity(entity_id, sample_time, -5.0, 5.0)
 
-    # Verify entity configuration is stored
-    assert entity_id in derivative_monitor.entities
     config = derivative_monitor.entities[entity_id]
     assert config["sample_time"] == sample_time
-    assert config["low_saturation"] == low_saturation
-    assert config["high_saturation"] == high_saturation
-
-    # Verify derivative entities are created in Home Assistant
-    mock_hass.set_state.assert_has_calls(
+    assert config["low_saturation"] == -5.0
+    assert config["high_saturation"] == 5.0
+    mqtt_entities.register_sensor.assert_has_calls(
         [
-                call(
-                    f"{entity_id}_rate",
-                    state=None,
-                    attributes={'friendly_name': 'sensor.temperature Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min', 'attribution': 'Data provided by SafetyFunction', 'icon': 'mdi:chart-timeline-variant'},
-                ),
-                call(
-                    f"{entity_id}_rateOfRate",
-                    state=None,
-                    attributes={'friendly_name': 'sensor.temperature Rate Of Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min²', 'attribution': 'Data provided by SafetyFunction', 'icon': 'mdi:chart-timeline-variant'},
-                ),
+            call(
+                f"{entity_id}_rate",
+                f"{entity_id} Rate",
+                state=None,
+                attributes={
+                    "friendly_name": f"{entity_id} Rate",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "°C/min",
+                    "attribution": "Data provided by SafetyFunction",
+                    "icon": "mdi:chart-timeline-variant",
+                },
+                icon="mdi:chart-timeline-variant",
+                unit_of_measurement="°C/min",
+                state_class="measurement",
+                entity_category="diagnostic",
+            ),
+            call(
+                f"{entity_id}_rateOfRate",
+                f"{entity_id} Rate Of Rate",
+                state=None,
+                attributes={
+                    "friendly_name": f"{entity_id} Rate Of Rate",
+                    "state_class": "measurement",
+                    "unit_of_measurement": "°C/min²",
+                    "attribution": "Data provided by SafetyFunction",
+                    "icon": "mdi:chart-timeline-variant",
+                },
+                icon="mdi:chart-timeline-variant",
+                unit_of_measurement="°C/min²",
+                state_class="measurement",
+                entity_category="diagnostic",
+            ),
         ]
     )
-    
     mock_hass.run_every.assert_called_with(
-        derivative_monitor._calculate_diff, "now", sample_time, entity_id=entity_id, sample_time=sample_time
+        derivative_monitor._calculate_diff,
+        "now",
+        sample_time,
+        entity_id=entity_id,
+        sample_time=sample_time,
     )
 
 
 def test_calculate_diff_updates_derivatives(setup_derivative_monitor):
-    """Test the calculation of first and second derivatives."""
-    mock_hass, derivative_monitor, set_mock_state = setup_derivative_monitor
-
+    """Test derivative calculation and MQTT state publication."""
+    _, mqtt_entities, derivative_monitor, set_mock_state = setup_derivative_monitor
     entity_id = "sensor.temperature"
     sample_time = 60
-    low_saturation = -10.0
-    high_saturation = 10.0
+    derivative_monitor.register_entity(entity_id, sample_time, -10.0, 10.0)
 
-    derivative_monitor.register_entity(entity_id, sample_time, low_saturation, high_saturation)
-
-    # Initial state change sets prev_value only
     set_mock_state(entity_id, 10.0)
     derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=sample_time)
     assert derivative_monitor.get_first_derivative(entity_id) is None
     assert derivative_monitor.get_second_derivative(entity_id) is None
 
-    # Second change sets first derivative (filtered)
     set_mock_state(entity_id, 13.0)
     derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=sample_time)
     assert derivative_monitor.get_first_derivative(entity_id) == 1.5
 
-    # Third change yields a non-zero second derivative
     set_mock_state(entity_id, 17.0)
     derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=sample_time)
     assert derivative_monitor.get_second_derivative(entity_id) == 1.25
-    mock_hass.set_state.assert_any_call(
+    mqtt_entities.publish_sensor_state.assert_any_call(
         f"{entity_id}_rate",
-        state=derivative_monitor.get_first_derivative(entity_id),
+        derivative_monitor.get_first_derivative(entity_id),
     )
-    mock_hass.set_state.assert_any_call(
+    mqtt_entities.publish_sensor_state.assert_any_call(
         f"{entity_id}_rateOfRate",
-        state=derivative_monitor.get_second_derivative(entity_id),
+        derivative_monitor.get_second_derivative(entity_id),
     )
 
 
 def test_calculate_diff_handles_missing_value(setup_derivative_monitor):
     """Ensure missing values skip calculation."""
-    mock_hass, derivative_monitor, _ = setup_derivative_monitor
+    mock_hass, _, derivative_monitor, _ = setup_derivative_monitor
     entity_id = "sensor.temperature"
-    sample_time = 10
-    derivative_monitor.register_entity(entity_id, sample_time, -5.0, 5.0)
+    derivative_monitor.register_entity(entity_id, 10, -5.0, 5.0)
 
-    mock_hass.get_state.return_value = None
-    derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=sample_time)
+    derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=10)
     mock_hass.log.assert_any_call(
         f"No value available for {entity_id}. Skipping calculation.",
         level="DEBUG",
@@ -124,15 +129,16 @@ def test_calculate_diff_handles_missing_value(setup_derivative_monitor):
 
 def test_unregistered_entity_error(setup_derivative_monitor):
     """Ensure an error is logged for unregistered entities."""
-    mock_hass, derivative_monitor, _ = setup_derivative_monitor
-    entity_id = "sensor.unregistered"
-    derivative_monitor._calculate_diff(entity_id=entity_id)
+    mock_hass, _, derivative_monitor, _ = setup_derivative_monitor
+    derivative_monitor._calculate_diff(entity_id="sensor.unregistered")
     mock_hass.log.assert_called_with(
-        f"Entity {entity_id} not registered for derivatives.", level="ERROR"
+        "Entity sensor.unregistered not registered for derivatives.",
+        level="ERROR",
     )
 
 
 def test_get_entity_value_invalid(setup_derivative_monitor):
-    mock_hass, derivative_monitor, _ = setup_derivative_monitor
+    mock_hass, _, derivative_monitor, _ = setup_derivative_monitor
+    mock_hass.get_state.side_effect = None
     mock_hass.get_state.return_value = "bad"
     assert derivative_monitor._get_entity_value("sensor.temperature") is None

--- a/backend/tests/test_derivative_monitor.py
+++ b/backend/tests/test_derivative_monitor.py
@@ -53,16 +53,16 @@ def test_register_entity(setup_derivative_monitor):
     # Verify derivative entities are created in Home Assistant
     mock_hass.set_state.assert_has_calls(
         [
-            call(
-                f"{entity_id}_rate",
-                state=None,
-                attributes={'friendly_name': 'sensor.temperature Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min', 'attribution': 'Data provided by SafetyFunction', 'device_class': 'temperature', 'icon': 'mdi:chart-timeline-variant'},
-            ),
-            call(
-                f"{entity_id}_rateOfRate",
-                state=None,
-                attributes={'friendly_name': 'sensor.temperature Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min', 'attribution': 'Data provided by SafetyFunction', 'device_class': 'temperature', 'icon': 'mdi:chart-timeline-variant'},
-            ),
+                call(
+                    f"{entity_id}_rate",
+                    state=None,
+                    attributes={'friendly_name': 'sensor.temperature Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min', 'attribution': 'Data provided by SafetyFunction', 'icon': 'mdi:chart-timeline-variant'},
+                ),
+                call(
+                    f"{entity_id}_rateOfRate",
+                    state=None,
+                    attributes={'friendly_name': 'sensor.temperature Rate Of Rate', 'state_class': 'measurement', 'unit_of_measurement': '°C/min²', 'attribution': 'Data provided by SafetyFunction', 'icon': 'mdi:chart-timeline-variant'},
+                ),
         ]
     )
     
@@ -97,7 +97,14 @@ def test_calculate_diff_updates_derivatives(setup_derivative_monitor):
     set_mock_state(entity_id, 17.0)
     derivative_monitor._calculate_diff(entity_id=entity_id, sample_time=sample_time)
     assert derivative_monitor.get_second_derivative(entity_id) == 1.25
-    mock_hass.set_state.assert_called_with(f"{entity_id}_rate", state=derivative_monitor.get_first_derivative(entity_id))
+    mock_hass.set_state.assert_any_call(
+        f"{entity_id}_rate",
+        state=derivative_monitor.get_first_derivative(entity_id),
+    )
+    mock_hass.set_state.assert_any_call(
+        f"{entity_id}_rateOfRate",
+        state=derivative_monitor.get_second_derivative(entity_id),
+    )
 
 
 def test_calculate_diff_handles_missing_value(setup_derivative_monitor):

--- a/backend/tests/test_fault_manager.py
+++ b/backend/tests/test_fault_manager.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch, ANY
 import pytest
+from components.core.event_bus import EventBus
+from components.core.mqtt_entity_manager import MqttEntityManager
 from components.core.types_common import FaultState, SMState, Symptom, Fault
 from components.faults_manager.fault_manager import FaultManager
 
@@ -22,7 +24,51 @@ def fault_manager(mocked_hass_app, symptom, fault):
     sm_modules = {"TemperatureComponent": Mock()}
     symptom_dict = {"RiskyTemperatureOffice": symptom}
     fault_dict = {"RiskyTemperature": fault}
-    return FaultManager(mocked_hass_app, sm_modules, symptom_dict, fault_dict)
+    event_bus = EventBus()
+    mqtt_entities = Mock(spec=MqttEntityManager)
+
+    def get_attributes(entity_id):
+        state = mocked_hass_app.get_state(entity_id, attribute="all")
+        return state.get("attributes", {}) if state else {}
+
+    mqtt_entities.get_attributes.side_effect = get_attributes
+    manager = FaultManager(
+        mocked_hass_app,
+        sm_modules,
+        symptom_dict,
+        fault_dict,
+        event_bus,
+        mqtt_entities,
+    )
+    manager.notify_spy = Mock()
+    manager.recovery_spy = Mock()
+
+    def notify_spy(
+        *,
+        fault_name,
+        level,
+        fault_state,
+        additional_info,
+        fault_tag,
+        should_notify=True,
+        **_,
+    ):
+        if should_notify:
+            manager.notify_spy(
+                fault_name,
+                level,
+                fault_state,
+                additional_info,
+                fault_tag,
+            )
+
+    def recovery_spy(*, fault_state, symptom, fault_tag, **_):
+        if fault_state != FaultState.SHADOWED:
+            manager.recovery_spy(symptom, fault_tag)
+
+    event_bus.subscribe("fault", notify_spy, priority=0)
+    event_bus.subscribe("fault", recovery_spy, priority=1)
+    return manager
 
 def test_fault_manager_initialization(fault_manager, fault, symptom):
     """
@@ -31,16 +77,10 @@ def test_fault_manager_initialization(fault_manager, fault, symptom):
     assert fault_manager.faults["RiskyTemperature"] == fault
     assert fault_manager.symptoms["RiskyTemperatureOffice"] == symptom
 
-def test_register_callbacks(fault_manager):
-    """
-    Test if register_callbacks sets the notify_interface and recovery_interface properly.
-    """
-    recovery_mock = Mock()
-    notify_mock = Mock()
-    fault_manager.register_callbacks(recovery_mock, notify_mock)
-
-    assert fault_manager.recovery_interface == recovery_mock
-    assert fault_manager.notify_interface == notify_mock
+def test_fault_manager_requires_event_bus_and_mqtt(fault_manager):
+    """Verify manager-to-manager events and entity output have explicit dependencies."""
+    assert isinstance(fault_manager.event_bus, EventBus)
+    assert fault_manager.mqtt_entities is not None
 
 def test_set_symptom(fault_manager, mocked_hass_app):
     """
@@ -78,8 +118,8 @@ def test_set_fault(fault_manager, mocked_hass_app, fault):
     """
     additional_info = {"Location": "Office"}
     fault_manager._generate_fault_tag = Mock(return_value="mocked_fault_tag")
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
 
     # Set up the mock for get_state to return appropriate data
     mocked_hass_app.get_state = Mock(return_value={"attributes": {"Location": "Kitchen"}})
@@ -87,19 +127,19 @@ def test_set_fault(fault_manager, mocked_hass_app, fault):
     fault_manager._set_fault("RiskyTemperatureOffice", additional_info)
 
     assert fault.state == FaultState.SET
-    mocked_hass_app.set_state.assert_any_call(
+    fault_manager.mqtt_entities.publish_sensor_state.assert_any_call(
         "sensor.fault_RiskyTemperature",
-        state="Set",
+        "Set",
         attributes={"Location": "Kitchen, Office"}
     )
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault.level,
         FaultState.SET,
-        additional_info,
+        {"Location": "Kitchen, Office"},
         "mocked_fault_tag"
     )
-    fault_manager.recovery_interface.assert_called_once_with(fault_manager.symptoms["RiskyTemperatureOffice"], "mocked_fault_tag")
+    fault_manager.recovery_spy.assert_called_once_with(fault_manager.symptoms["RiskyTemperatureOffice"], "mocked_fault_tag")
 
 def test_clear_fault(fault_manager, mocked_hass_app, fault):
     """
@@ -107,8 +147,8 @@ def test_clear_fault(fault_manager, mocked_hass_app, fault):
     """
     additional_info = {"Location": "Office"}
     fault_manager._generate_fault_tag = Mock(return_value="mocked_fault_tag")
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
 
     # Set up the mock for get_state to return appropriate data
     mocked_hass_app.get_state = Mock(return_value={"attributes": {"Location": "Office"}})
@@ -120,19 +160,19 @@ def test_clear_fault(fault_manager, mocked_hass_app, fault):
     fault_manager._clear_fault("RiskyTemperatureOffice", additional_info)
 
     assert fault.state == FaultState.CLEARED
-    mocked_hass_app.set_state.assert_any_call(
+    fault_manager.mqtt_entities.publish_sensor_state.assert_any_call(
         "sensor.fault_RiskyTemperature",
-        state="Cleared",
+        "Cleared",
         attributes={"Location": ""}
     )
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault.level,
         FaultState.CLEARED,
         additional_info,
         "mocked_fault_tag"
     )
-    fault_manager.recovery_interface.assert_any_call(fault_manager.symptoms["RiskyTemperatureOffice"], "mocked_fault_tag")
+    fault_manager.recovery_spy.assert_any_call(fault_manager.symptoms["RiskyTemperatureOffice"], "mocked_fault_tag")
 
 def test_found_mapped_fault(fault_manager, fault):
     """
@@ -160,8 +200,8 @@ def test_fault_manager_multiple_symptoms(fault_manager, mocked_hass_app, fault):
     """
     # Mock the recovery and notification interfaces
     fault_manager._generate_fault_tag = Mock(return_value="mocked_fault_tag")
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
 
     # Define multiple symptoms for testing
     symptom_office = Symptom(
@@ -196,19 +236,19 @@ def test_fault_manager_multiple_symptoms(fault_manager, mocked_hass_app, fault):
 
     # Verify the fault state is set and includes both locations (Living Room, Office)
     assert fault.state == FaultState.SET
-    mocked_hass_app.set_state.assert_any_call(
+    fault_manager.mqtt_entities.publish_sensor_state.assert_any_call(
         "sensor.fault_RiskyTemperature",
-        state="Set",
+        "Set",
         attributes={"Location": "Living Room, Office"},
     )
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault.level,
         FaultState.SET,
-        additional_info_office,
+        {"Location": "Living Room, Office"},
         "mocked_fault_tag",
     )
-    fault_manager.recovery_interface.assert_any_call(
+    fault_manager.recovery_spy.assert_any_call(
         symptom_office, "mocked_fault_tag"
     )
     
@@ -218,19 +258,19 @@ def test_fault_manager_multiple_symptoms(fault_manager, mocked_hass_app, fault):
     
     # Verify the fault state is set and includes both locations (Living Room, Office)
     assert fault.state == FaultState.SET
-    mocked_hass_app.set_state.assert_any_call(
+    fault_manager.mqtt_entities.publish_sensor_state.assert_any_call(
         "sensor.fault_RiskyTemperature",
-        state="Set",
+        "Set",
         attributes={"Location": "Living Room, Kitchen"}, # In normal system shall be also included Office but we dont have HA during tests
     )
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault.level,
         FaultState.SET,
-        additional_info_kitchen,
+        {"Location": "Living Room, Kitchen"},
         "mocked_fault_tag",
     )
-    fault_manager.recovery_interface.assert_any_call(
+    fault_manager.recovery_spy.assert_any_call(
         symptom_kitchen, "mocked_fault_tag"
     )
 
@@ -245,19 +285,19 @@ def test_fault_manager_multiple_symptoms(fault_manager, mocked_hass_app, fault):
 
     # Verify the fault is now cleared as all related symptoms are cleared
     assert fault.state == FaultState.CLEARED
-    mocked_hass_app.set_state.assert_any_call(
+    fault_manager.mqtt_entities.publish_sensor_state.assert_any_call(
         "sensor.fault_RiskyTemperature",
-        state="Cleared",
+        "Cleared",
         attributes={"Location": ""},
     )
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault.level,
         FaultState.CLEARED,
         additional_info_kitchen,
         "mocked_fault_tag",
     )
-    fault_manager.recovery_interface.assert_any_call(
+    fault_manager.recovery_spy.assert_any_call(
         symptom_kitchen, "mocked_fault_tag"
     )
 
@@ -269,8 +309,8 @@ def test_fault_manager_multiple_sm_names_single_fault(
     Test that a fault mapped to multiple safety mechanism names clears only when all related symptoms are cleared.
     """
     fault_manager._generate_fault_tag = Mock(return_value="mocked_fault_tag")
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
 
     symptom_low = Symptom(
         name="RiskyTemperatureOffice",
@@ -312,8 +352,8 @@ def test_fault_manager_state_transitions(fault_manager, mocked_hass_app, fault):
     """
     # Mock the recovery and notification interfaces
     fault_manager._generate_fault_tag = Mock(return_value="mocked_fault_tag")
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
 
     # Define two symptoms that relate to different faults
     symptom1 = Symptom(
@@ -350,11 +390,11 @@ def test_fault_manager_state_transitions(fault_manager, mocked_hass_app, fault):
 
     # Verify fault1 is set
     assert fault1.state == FaultState.SET
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault1.level,
         FaultState.SET,
-        additional_info1,
+        {"Location": "Living Room, Office"},
         "mocked_fault_tag",
     )
 
@@ -364,11 +404,11 @@ def test_fault_manager_state_transitions(fault_manager, mocked_hass_app, fault):
 
     # Verify fault2 is set
     assert fault2.state == FaultState.SET
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "OverheatingFault",
         fault2.level,
         FaultState.SET,
-        additional_info2,
+        {"Location": "Living Room, Kitchen"},
         "mocked_fault_tag",
     )
 
@@ -377,7 +417,7 @@ def test_fault_manager_state_transitions(fault_manager, mocked_hass_app, fault):
 
     # Verify fault1 is cleared
     assert fault1.state == FaultState.CLEARED
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperature",
         fault1.level,
         FaultState.CLEARED,
@@ -393,7 +433,7 @@ def test_fault_manager_state_transitions(fault_manager, mocked_hass_app, fault):
 
     # Verify fault2 is cleared
     assert fault2.state == FaultState.CLEARED
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "OverheatingFault",
         fault2.level,
         FaultState.CLEARED,
@@ -406,8 +446,8 @@ def test_fault_shadowing_clears_notification(fault_manager, mocked_hass_app):
     """
     Test that a fault listed in a shadowing rule is shadowed and its notification cleared.
     """
-    fault_manager.notify_interface = Mock()
-    fault_manager.recovery_interface = Mock()
+    fault_manager.notify_spy.reset_mock()
+    fault_manager.recovery_spy.reset_mock()
     mocked_hass_app.get_state = Mock(return_value={"attributes": {"Location": "Office"}})
 
     symptom_actual = Symptom(
@@ -448,7 +488,7 @@ def test_fault_shadowing_clears_notification(fault_manager, mocked_hass_app):
     assert fault_actual.state == FaultState.SET
     assert fault_forecast.state == FaultState.SHADOWED
 
-    fault_manager.notify_interface.assert_any_call(
+    fault_manager.notify_spy.assert_any_call(
         "RiskyTemperatureForecast",
         fault_forecast.level,
         FaultState.SHADOWED,
@@ -480,60 +520,6 @@ def test_fault_manager_init_safety_mechanisms_failure(fault_manager):
 
     # Verify that the symptom state is set to ERROR
     assert fault_manager.symptoms["FaultyTemperatureSensor"].sm_state == SMState.ERROR
-    
-def test_fault_manager_missing_interfaces(fault_manager, mocked_hass_app):
-    """
-    Test the behavior of the FaultManager when notification or recovery interfaces are missing.
-    """
-    # Define a symptom
-    symptom = Symptom(
-        name="RiskyTemperatureOffice",
-        sm_name="sm_tc_1",
-        module=Mock(),
-        parameters={"CAL_LOW_TEMP_THRESHOLD": 18.0},
-    )
-
-    # Set up the mock for get_state to simulate a previous location being set
-    mocked_hass_app.get_state = Mock(
-        return_value={"attributes": {"Location": "Office"}}
-    )
-    
-    # Add the symptom to the fault manager
-    fault_manager.symptoms["RiskyTemperatureOffice"] = symptom
-
-    # Add a fault that the symptom relates to
-    fault = Fault("RiskyTemperature", ["sm_tc_1"], level=2)
-    fault_manager.faults["RiskyTemperature"] = fault
-
-    # Set symptom without recovery and notification interfaces
-    fault_manager.set_symptom("RiskyTemperatureOffice", {"Location": "Office"})
-
-    # Verify that fault is set
-    assert fault.state == FaultState.SET
-    mocked_hass_app.set_state.assert_any_call(
-        "sensor.fault_RiskyTemperature",
-        state="Set",
-        attributes={"Location": "Office"},
-    )
-
-    # Verify that no notification or recovery calls are made
-    assert fault_manager.notify_interface is None
-    assert fault_manager.recovery_interface is None
-
-    # Clear symptom without recovery and notification interfaces
-    fault_manager.clear_symptom("RiskyTemperatureOffice", {"Location": "Office"})
-
-    # Verify that fault is cleared
-    assert fault.state == FaultState.CLEARED
-    mocked_hass_app.set_state.assert_any_call(
-        "sensor.fault_RiskyTemperature",
-        state="Cleared",
-        attributes={"Location": ""},
-    )
-
-    # Verify that no notification or recovery calls are made
-    assert fault_manager.notify_interface is None
-    assert fault_manager.recovery_interface is None
     
 def test_fault_manager_cleared_state_determinate_info(fault_manager, mocked_hass_app):
     """

--- a/backend/tests/test_mqtt_entity_manager.py
+++ b/backend/tests/test_mqtt_entity_manager.py
@@ -1,0 +1,181 @@
+"""Tests for MQTT discovery and state publishing."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from pydantic import ValidationError
+
+from components.core.mqtt_entity_manager import MqttEntityManager
+
+
+def _mqtt_calls(hass_app, topic):
+    return [
+        call
+        for call in hass_app.call_service.call_args_list
+        if call.args
+        and call.args[0] == "mqtt/publish"
+        and call.kwargs["topic"] == topic
+    ]
+
+
+def test_register_sensor_publishes_discovery_state_and_attributes():
+    hass_app = Mock()
+    mqtt_entities = MqttEntityManager(hass_app)
+
+    mqtt_entities.register_sensor(
+        "sensor.safety_app_health",
+        "Safety App Health",
+        state="running",
+        attributes={"mode": "test"},
+        icon="mdi:heart-pulse",
+    )
+
+    discovery_call = _mqtt_calls(
+        hass_app,
+        "homeassistant/sensor/safety_component_safety_app_health/config",
+    )[-1]
+    discovery_payload = json.loads(discovery_call.kwargs["payload"])
+
+    assert discovery_call.kwargs["retain"] is True
+    assert discovery_payload["state_topic"] == "safety_component/state/safety_app_health"
+    assert (
+        discovery_payload["json_attributes_topic"]
+        == "safety_component/attributes/safety_app_health"
+    )
+    assert discovery_payload["unique_id"] == "safety_component_safety_app_health"
+    assert discovery_payload["default_entity_id"] == "sensor.safety_app_health"
+    assert discovery_payload["expire_after"] == 180
+    assert discovery_payload["origin"]["name"] == "SafetyComponent"
+
+    state_call = _mqtt_calls(
+        hass_app, "safety_component/state/safety_app_health"
+    )[-1]
+    assert state_call.kwargs["payload"] == "running"
+    assert state_call.kwargs["retain"] is False
+    attributes_payload = json.loads(
+        _mqtt_calls(hass_app, "safety_component/attributes/safety_app_health")[
+            -1
+        ].kwargs["payload"]
+    )
+    assert attributes_payload == {"mode": "test"}
+
+
+def test_availability_cleanup_and_remove_sensor():
+    hass_app = Mock()
+    mqtt_entities = MqttEntityManager(
+        hass_app,
+        {
+            "legacy_discovery_entity_ids": ["sensor.safety_app_health"]
+        },
+    )
+
+    mqtt_entities.cleanup_legacy_discovery_topics()
+    mqtt_entities.publish_availability(True)
+    mqtt_entities.register_sensor("sensor.test", "Test", state="ok")
+    mqtt_entities.remove_sensor("sensor.test", remove_legacy_topic=True)
+
+    availability_call = _mqtt_calls(hass_app, "safety_component/status")[-1]
+    assert availability_call.kwargs["payload"] == "online"
+    assert availability_call.kwargs["retain"] is True
+
+    legacy_health_call = _mqtt_calls(
+        hass_app, "homeassistant/sensor/safety_app_health/config"
+    )[0]
+    assert legacy_health_call.kwargs["payload"] == ""
+    assert legacy_health_call.kwargs["retain"] is True
+
+    for topic in (
+        "homeassistant/sensor/safety_component_test/config",
+        "homeassistant/sensor/test/config",
+        "safety_component/state/test",
+        "safety_component/attributes/test",
+    ):
+        cleanup_call = _mqtt_calls(hass_app, topic)[-1]
+        assert cleanup_call.kwargs["payload"] == ""
+        assert cleanup_call.kwargs["retain"] is True
+
+
+def test_entity_ids_are_canonical_and_none_is_an_explicit_unknown_state():
+    hass_app = Mock()
+    mqtt_entities = MqttEntityManager(hass_app)
+
+    canonical_id = mqtt_entities.register_sensor(
+        "sensor.Fault_RiskyTemperature",
+        "Risky temperature",
+        state=None,
+    )
+
+    assert canonical_id == "sensor.fault_riskytemperature"
+    assert (
+        _mqtt_calls(
+            hass_app,
+            "safety_component/state/fault_riskytemperature",
+        )[-1].kwargs["payload"]
+        == "None"
+    )
+    discovery_call = _mqtt_calls(
+        hass_app,
+        "homeassistant/sensor/"
+        "safety_component_fault_riskytemperature/config",
+    )[-1]
+    discovery_payload = json.loads(discovery_call.kwargs["payload"])
+    assert (
+        discovery_payload["default_entity_id"]
+        == "sensor.fault_riskytemperature"
+    )
+
+
+@pytest.mark.parametrize(
+    "mqtt_config",
+    [
+        {"qos": 3},
+        {"retain_discovery": False},
+        {"base_topic": "unsafe/#"},
+        {"retain_state": "false"},
+        {"device_identifier": "Unsafe Identifier"},
+        {"heartbeat_seconds": 0, "expire_after": 60},
+        {"heartbeat_seconds": 60, "expire_after": 60},
+        {"legacy_discovery_entity_ids": ["light.not_a_sensor"]},
+    ],
+)
+def test_invalid_mqtt_settings_are_rejected(mqtt_config):
+    with pytest.raises((ValidationError, ValueError)):
+        MqttEntityManager(Mock(), mqtt_config)
+
+
+def test_heartbeat_republishes_cached_states_without_retaining_them():
+    hass_app = Mock()
+    mqtt_entities = MqttEntityManager(hass_app)
+    mqtt_entities.register_sensor(
+        "sensor.health",
+        "Health",
+        state="running",
+        attributes={"configuration": {"version": 1}},
+    )
+
+    hass_app.call_service.reset_mock()
+    mqtt_entities.publish_heartbeat()
+
+    state_call = _mqtt_calls(hass_app, "safety_component/state/health")[-1]
+    assert state_call.kwargs["payload"] == "running"
+    assert state_call.kwargs["retain"] is False
+    attributes_call = _mqtt_calls(
+        hass_app, "safety_component/attributes/health"
+    )[-1]
+    assert json.loads(attributes_call.kwargs["payload"]) == {
+        "configuration": {"version": 1}
+    }
+    assert attributes_call.kwargs["retain"] is False
+
+
+def test_failed_mqtt_publish_response_is_rejected():
+    hass_app = Mock(
+        call_service=Mock(
+            return_value={"success": False, "error": "broker unavailable"}
+        )
+    )
+    mqtt_entities = MqttEntityManager(hass_app)
+
+    with pytest.raises(RuntimeError, match="MQTT publish failed"):
+        mqtt_entities.publish_availability()

--- a/backend/tests/test_notify_man.py
+++ b/backend/tests/test_notify_man.py
@@ -188,7 +188,6 @@ def test_notify_fault_set(mocked_hass_app_with_temp_component):
     notification_config: dict[str, str] = {
         "light_entity": "light.warning_light",
         "alarm_entity": "alarm_control_panel.safety_alarm",
-        "dashboard_1_entity": "sensor.dash_emergency",
     }
     app_instance, _, __, ___, mock_behaviors_default = (
     mocked_hass_app_with_temp_component
@@ -230,9 +229,7 @@ def test_notify_fault_cleared(mocked_hass_app_with_temp_component):
     app_instance, _, __, ___, mock_behaviors_default = (
         mocked_hass_app_with_temp_component
     )
-    notification_config = {
-        "dashboard_1_entity": "sensor.dash_emergency",
-    }
+    notification_config = {}
 
     notification_manager = NotificationManager(app_instance, notification_config)
     app_instance.call_service = Mock()
@@ -283,9 +280,7 @@ def test_notify_company_app(mocked_hass_app_with_temp_component):
     app_instance, _, __, ___, mock_behaviors_default = (
         mocked_hass_app_with_temp_component
     )
-    notification_config = {
-        "dashboard_1_entity": "sensor.dash_emergency",
-    }
+    notification_config = {}
 
     notification_manager = NotificationManager(app_instance, notification_config)
     app_instance.call_service = Mock()
@@ -330,46 +325,6 @@ def test_notify_invalid_fault_status(mocked_hass_app_with_temp_component):
 
     # Verify that a warning log was triggered for the invalid fault status
     app_instance.log.assert_called_with(f"Invalid fault status '{fault_status}'", level="WARNING")
-    
-def test_set_dashboard_notification(mocked_hass_app_with_temp_component):
-    """
-    Test Case: Set dashboard notification.
-
-    Scenario:
-        - Set a notification on the dashboard based on severity level.
-        - Expected Result: The dashboard entity state is updated, or a warning is logged if the entity is not configured.
-    """
-    app_instance, _, __, ___, mock_behaviors_default = (
-        mocked_hass_app_with_temp_component
-    )
-    notification_config = {
-        "dashboard_1_entity": "sensor.dash_emergency"
-    }
-
-    notification_manager = NotificationManager(app_instance, notification_config)
-    app_instance.set_state = Mock()
-    app_instance.log = Mock()
-
-    message = "Test Dashboard Message"
-    level = 1
-
-    # Call _set_dashboard_notification with a valid level
-    notification_manager._set_dashboard_notification(message, level)
-
-    # Verify that the dashboard entity state was set
-    app_instance.set_state.assert_called_with("sensor.dash_emergency", state=message)
-    app_instance.log.assert_called_with(
-        f"Dashboard entity sensor.dash_emergency was changed to {message}", level="DEBUG"
-    )
-
-    # Call _set_dashboard_notification with an invalid level (not configured)
-    level = 2
-    notification_manager._set_dashboard_notification(message, level)
-
-    # Verify that a warning log was triggered for missing dashboard entity configuration
-    app_instance.log.assert_called_with(
-        f"No dashboard entity configured for level '{level}'", level="WARNING"
-    )
     
 def test_notify_company_app_no_notification_data(mocked_hass_app_with_temp_component):
     """

--- a/backend/tests/test_recovery_man.py
+++ b/backend/tests/test_recovery_man.py
@@ -2,7 +2,10 @@
 # mypy: ignore-errors
 
 from components.core.types_common import FaultState, RecoveryResult, RecoveryActionState, Fault, Symptom, RecoveryAction
+from components.recovery_manager.recovery_manager import RecoveryManager
 from unittest.mock import Mock
+
+import pytest
 
 
 def test_recovery_cleared_state(mocked_hass_app_with_temp_component):
@@ -75,6 +78,7 @@ def test_no_recovery_changes_needed(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = None
     recovery_action.params = {}  # Ensure that params attribute is a valid dictionary
     recovery_manager.recovery_actions = {symptom.name: recovery_action}
@@ -106,6 +110,7 @@ def test_recovery_validation_fails(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_result = Mock()
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}  # Ensure that params attribute is a valid dictionary
@@ -138,6 +143,7 @@ def test_successful_recovery_execution(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_result = Mock()
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}  # Ensure that params attribute is a valid dictionary
@@ -170,6 +176,7 @@ def test_dry_test_failure_aborts_recovery(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_result = Mock()
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
@@ -211,6 +218,7 @@ def test_recovery_conflict_aborts_recovery(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_result = Mock()
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
@@ -253,6 +261,7 @@ def test_successful_recovery_execution(mocked_hass_app_with_temp_component):
 
     recovery_manager = app_instance.reco_man
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_result = Mock()
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
@@ -290,10 +299,11 @@ def test_recovery_execution_multiple_entities(mocked_hass_app_with_temp_componen
     recovery_manager = app_instance.reco_man
     recovery_result = RecoveryResult(
         changed_sensors={"sensor.test_1": "on", "sensor.test_2": "off"},
-        changed_actuators={"actuator_1": "active", "actuator_2": "inactive"},
+        changed_actuators={"switch.actuator_1": "on", "light.actuator_2": "off"},
         notifications=[],
     )
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
     recovery_manager.recovery_actions = {symptom.name: recovery_action}
@@ -302,9 +312,12 @@ def test_recovery_execution_multiple_entities(mocked_hass_app_with_temp_componen
 
     recovery_manager.recovery(symptom,"00")
 
-    # Validate that all entities are updated correctly
-    app_instance.set_state.assert_any_call("actuator_1", state="active")
-    app_instance.set_state.assert_any_call("actuator_2", state="inactive")
+    app_instance.call_service.assert_any_call(
+        "switch/turn_on", entity_id="switch.actuator_1"
+    )
+    app_instance.call_service.assert_any_call(
+        "light/turn_off", entity_id="light.actuator_2"
+    )
 
 
 def test_integration_with_fault_and_notification_managers(
@@ -337,10 +350,11 @@ def test_integration_with_fault_and_notification_managers(
     recovery_manager = app_instance.reco_man
     recovery_result = RecoveryResult(
         changed_sensors={},  # No sensor changes
-        changed_actuators={"actuator_1": "active"},
+        changed_actuators={"switch.actuator_1": "on"},
         notifications=["Manual intervention required for actuator_1."],
     )
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
     recovery_manager.recovery_actions = {symptom.name: recovery_action}
@@ -360,8 +374,9 @@ def test_integration_with_fault_and_notification_managers(
     recovery_manager._isRecoveryConflict = Mock(return_value=False)
     recovery_manager.recovery(symptom,fault_tag)
 
-    # Validate that actuators are updated correctly
-    app_instance.set_state.assert_any_call("actuator_1", state="active")
+    app_instance.call_service.assert_any_call(
+        "switch/turn_on", entity_id="switch.actuator_1"
+    )
 
     # Validate that the notification action was called correctly
     notification_manager._add_recovery_action.assert_called_once_with(
@@ -389,10 +404,11 @@ def test_recovery_action_state_transition(mocked_hass_app_with_temp_component):
     recovery_manager = app_instance.reco_man
     recovery_result = RecoveryResult(
         changed_sensors={"sensor.test_1": "on", "sensor.test_2": "off"},
-        changed_actuators={"actuator_1": "active", "actuator_2": "inactive"},
+        changed_actuators={"switch.actuator_1": "on", "light.actuator_2": "off"},
         notifications=[],
     )
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
     recovery_action.current_status = RecoveryActionState.DO_NOT_PERFORM
@@ -491,6 +507,7 @@ def test_recovery_conflict_with_higher_priority(mocked_hass_app_with_temp_compon
         notifications=[],
     )
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
     recovery_action.name = "MatchingAction"  # Set name to a non-mock value
@@ -560,12 +577,13 @@ def test_perform_recovery_with_exception_handling(mocked_hass_app_with_temp_comp
     recovery_manager = app_instance.reco_man
     recovery_result = RecoveryResult(
         changed_sensors={"sensor.test_1": "on", "sensor.test_2": "off"},
-        changed_actuators={"actuator_1": "active", "actuator_2": "inactive"},
+        changed_actuators={"switch.actuator_1": "on", "light.actuator_2": "off"},
         notifications=["Test notification"],
     )
 
     # Mocking a RecoveryAction
     recovery_action = Mock()
+    recovery_action.name = symptom.name
     recovery_action.rec_fun.return_value = recovery_result
     recovery_action.params = {}
     recovery_action.current_status = RecoveryActionState.DO_NOT_PERFORM
@@ -577,29 +595,39 @@ def test_perform_recovery_with_exception_handling(mocked_hass_app_with_temp_comp
     fault_tag = 'BE'
     recovery_manager.fm.found_mapped_fault = Mock(return_value=found_fault)
 
-    # Mock `set_state` to throw an exception for one of the entities
-    def mock_set_state(entity, state):
-        if entity == "actuator_1":
-            raise Exception("Simulated set_state error")
-        else:
-            pass
+    # Simulate one failed HA service while allowing the next actuator to proceed.
+    def mock_execute_action(entity, _state):
+        if entity == "switch.actuator_1":
+            raise RuntimeError("Simulated service error")
 
-    recovery_manager.hass_app.set_state = Mock(side_effect=mock_set_state)
+    recovery_manager._execute_entity_action = Mock(
+        side_effect=mock_execute_action
+    )
     recovery_manager.hass_app.log = Mock()
     recovery_manager.nm._add_recovery_action  = Mock()
     
     # Call `_perform_recovery`
-    recovery_manager._perform_recovery(symptom, recovery_result.notifications, recovery_result.changed_actuators, fault_tag)
+    executed_changes = recovery_manager._perform_recovery(
+        symptom,
+        recovery_result.notifications,
+        recovery_result.changed_actuators,
+        fault_tag,
+    )
 
     # Validate that the correct error was logged
     recovery_manager.hass_app.log.assert_any_call(
-        "Exception during setting actuator_1 to active value. Simulated set_state error",
+        "Exception during setting switch.actuator_1 to on value. "
+        "Simulated service error",
         level="ERROR",
     )
 
-    # Assert that `set_state` was called for other entities despite the exception
-    recovery_manager.hass_app.set_state.assert_any_call("actuator_1", state="active")
-    recovery_manager.hass_app.set_state.assert_any_call("actuator_2", state="inactive")
+    recovery_manager._execute_entity_action.assert_any_call(
+        "switch.actuator_1", "on"
+    )
+    recovery_manager._execute_entity_action.assert_any_call(
+        "light.actuator_2", "off"
+    )
+    assert executed_changes == {"light.actuator_2": "off"}
 
     # Assert that notifications were processed
     recovery_manager.nm._add_recovery_action.assert_called_once_with("Test notification", fault_tag)
@@ -768,10 +796,238 @@ def test_recovery_performed_callback(mocked_hass_app_with_temp_component):
     symptom.name = "TestSymptom"
 
     # Call `_recovery_performed` directly with the mock callback arguments
-    cb_args = {"symptom": symptom}
+    recovery_manager._pending_recovery_confirmations[symptom.name] = {
+        "sensor.test": "on"
+    }
+    recovery_manager.hass_app.get_state = Mock(return_value="on")
+    cb_args = {
+        "symptom": symptom,
+        "confirmation_entity": "sensor.test",
+        "expected_state": "on",
+    }
 
     # Invoke the callback function directly
-    recovery_manager._recovery_performed(None, None, None, None, cb_args)
+    recovery_manager._recovery_performed(None, None, None, "on", **cb_args)
 
     # Assert that `_recovery_clear` was called with the expected symptom
+    recovery_manager._recovery_clear.assert_called_once_with(symptom)
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value", "expected_service"),
+    [
+        ("cover.office_window", "on", "cover/open_cover"),
+        ("cover.office_window", "off", "cover/close_cover"),
+        ("switch.warning", "on", "switch/turn_on"),
+        ("light.warning", "off", "light/turn_off"),
+        ("fan.ventilation", "on", "fan/turn_on"),
+    ],
+)
+def test_resolve_entity_action(entity_id, value, expected_service):
+    assert (
+        RecoveryManager._resolve_entity_action(entity_id, value)
+        == expected_service
+    )
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "value"),
+    [
+        ("lock.front_door", "off"),
+        ("cover.office_window", "toggle"),
+        ("switch.warning", "active"),
+        ("invalid_entity", "on"),
+    ],
+)
+def test_resolve_entity_action_rejects_unsafe_or_unknown_actions(
+    entity_id, value
+):
+    with pytest.raises(ValueError):
+        RecoveryManager._resolve_entity_action(entity_id, value)
+
+
+def test_execute_entity_action_rejects_failed_service_response(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    app_instance.call_service = Mock(
+        return_value={"success": False, "error": "service rejected"}
+    )
+
+    with pytest.raises(RuntimeError, match="rejected"):
+        app_instance.reco_man._execute_entity_action(
+            "cover.office_window", "off"
+        )
+
+
+def test_recovery_waits_for_all_postconditions(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    recovery_manager = app_instance.reco_man
+    recovery_manager._recovery_clear = Mock()
+
+    symptom = Mock()
+    symptom.name = "MultiConfirmation"
+    recovery_manager._pending_recovery_confirmations[symptom.name] = {
+        "binary_sensor.window_a": "off",
+        "binary_sensor.window_b": "off",
+    }
+    current_states = {
+        "binary_sensor.window_a": "off",
+        "binary_sensor.window_b": "on",
+    }
+    recovery_manager.hass_app.get_state = Mock(
+        side_effect=lambda entity_id: current_states[entity_id]
+    )
+
+    recovery_manager._recovery_performed(
+        None,
+        None,
+        None,
+        "off",
+        symptom=symptom,
+        confirmation_entity="binary_sensor.window_a",
+        expected_state="off",
+    )
+    recovery_manager._recovery_clear.assert_not_called()
+
+    current_states["binary_sensor.window_b"] = "off"
+    recovery_manager._recovery_performed(
+        None,
+        None,
+        None,
+        "off",
+        symptom=symptom,
+        confirmation_entity="binary_sensor.window_b",
+        expected_state="off",
+    )
+    recovery_manager._recovery_clear.assert_called_once_with(symptom)
+
+
+def test_stale_listener_cannot_clear_retriggered_recovery(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    recovery_manager = app_instance.reco_man
+    recovery_manager._recovery_clear = Mock()
+
+    symptom = Mock()
+    symptom.name = "Retriggered"
+    recovery_manager._pending_recovery_confirmations[symptom.name] = {
+        "cover.office_window": "open"
+    }
+
+    recovery_manager._recovery_performed(
+        None,
+        None,
+        None,
+        "closed",
+        symptom=symptom,
+        confirmation_entity="cover.office_window",
+        expected_state="closed",
+    )
+
+    recovery_manager._recovery_clear.assert_not_called()
+
+
+def test_delayed_callback_does_not_replace_current_entity_state(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    recovery_manager = app_instance.reco_man
+    recovery_manager._recovery_clear = Mock()
+    recovery_manager.hass_app.get_state = Mock(return_value="open")
+
+    symptom = Mock()
+    symptom.name = "DelayedCallback"
+    recovery_manager._pending_recovery_confirmations[symptom.name] = {
+        "cover.office_window": "closed"
+    }
+
+    recovery_manager._recovery_performed(
+        None,
+        None,
+        None,
+        "closed",
+        symptom=symptom,
+        confirmation_entity="cover.office_window",
+        expected_state="closed",
+    )
+
+    recovery_manager._recovery_clear.assert_not_called()
+
+
+def test_actuator_only_cover_waits_for_closed_state(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    recovery_manager = app_instance.reco_man
+    recovery_manager.hass_app.listen_state.reset_mock()
+
+    symptom = Mock()
+    symptom.name = "CoverFallback"
+    recovery_manager._listen_to_changes(
+        symptom,
+        {},
+        {"cover.office_window": "off"},
+    )
+
+    recovery_manager.hass_app.listen_state.assert_called_once_with(
+        recovery_manager._recovery_performed,
+        "cover.office_window",
+        new="closed",
+        symptom=symptom,
+        confirmation_entity="cover.office_window",
+        expected_state="closed",
+    )
+
+
+def test_recovery_listeners_remain_active_until_all_postconditions_match(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    recovery_manager = app_instance.reco_man
+    recovery_manager._recovery_clear = Mock()
+    current_states = {
+        "binary_sensor.window_a": "off",
+        "binary_sensor.window_b": "on",
+    }
+    recovery_manager.hass_app.get_state = Mock(
+        side_effect=lambda entity_id: current_states[entity_id]
+    )
+
+    symptom = Mock()
+    symptom.name = "PersistentConfirmation"
+    recovery_manager._listen_to_changes(
+        symptom,
+        {
+            "binary_sensor.window_a": "off",
+            "binary_sensor.window_b": "off",
+        },
+        {},
+    )
+
+    assert recovery_manager.hass_app.listen_state.call_count >= 2
+    for listen_call in recovery_manager.hass_app.listen_state.call_args_list[-2:]:
+        assert "oneshot" not in listen_call.kwargs
+        assert "immediate" not in listen_call.kwargs
+    recovery_manager._recovery_clear.assert_not_called()
+
+    current_states["binary_sensor.window_b"] = "off"
+    recovery_manager._recovery_performed(
+        None,
+        None,
+        None,
+        "off",
+        symptom=symptom,
+        confirmation_entity="binary_sensor.window_b",
+        expected_state="off",
+    )
     recovery_manager._recovery_clear.assert_called_once_with(symptom)

--- a/backend/tests/test_safetyFunctions.py
+++ b/backend/tests/test_safetyFunctions.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, patch
 from .fixtures.hass_fixture import (
     mock_get_state,
     MockBehavior,
+    mqtt_payloads,
+    mqtt_topic_for,
     update_mocked_get_state,
 )  # Import utilities from conftest.py
 from unittest.mock import ANY
@@ -37,9 +39,34 @@ def test_safety_functions_initialization(mocked_hass_app_with_temp_component) ->
     # Ensure that the correct common entity was used
     assert app_instance.common_entities_cfg["outside_temp"] == "sensor.dom_temperature"
 
-    # Verify that safety mechanisms are initialized and enabled
-    mocked_hass.set_state.assert_any_call("sensor.safety_app_health", state="init")
-    mocked_hass.set_state.assert_any_call("sensor.safety_app_health", state="running",attributes = ANY)
+    # Verify that safety mechanisms are initialized and enabled via MQTT state.
+    health_topic = mqtt_topic_for("sensor.safety_app_health")
+    health_payloads = mqtt_payloads(mocked_hass, health_topic)
+    assert "init" in health_payloads
+    assert "running" in health_payloads
+    assert mqtt_payloads(mocked_hass, "safety_component/status") == [
+        "offline",
+        "online",
+    ]
+    assert {
+        "sensor.safetysystem_state",
+        "sensor.fault_riskytemperature",
+        "sensor.fault_riskytemperatureforecast",
+        "sensor.recovery_manipulatewindowoffice",
+    }.issubset(app_instance.mqtt_entities.discovered_entities)
+
+
+def test_mqtt_heartbeat_accepts_appdaemon_dictionary_unpacking_callback(
+    mocked_hass_app_with_temp_component,
+) -> None:
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+    app_instance.mqtt_entities.publish_heartbeat = Mock()
+
+    app_instance._mqtt_heartbeat()
+    app_instance._mqtt_heartbeat(timer="heartbeat")
+
+    assert app_instance.mqtt_entities.publish_heartbeat.call_count == 2
 
     # Verify TemperatureComponent configurations are set up correctly
     assert "TemperatureComponent" in app_instance.sm_modules
@@ -119,9 +146,35 @@ def test_app_initialization_health_state(mocked_hass_app_with_temp_component):
 
     app_instance.initialize()
 
-    # Verify that health state transitions from 'init' to 'good'
-    mocked_hass.set_state.assert_any_call("sensor.safety_app_health", state="init")
-    mocked_hass.set_state.assert_any_call("sensor.safety_app_health", state="running",attributes = ANY)
+    # Verify that health state transitions from 'init' to 'running'.
+    health_topic = mqtt_topic_for("sensor.safety_app_health")
+    health_payloads = mqtt_payloads(mocked_hass, health_topic)
+    assert "init" in health_payloads
+    assert "running" in health_payloads
+
+
+def test_terminate_publishes_offline(mocked_hass_app_with_temp_component):
+    app_instance, mocked_hass, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.initialize()
+
+    app_instance.terminate()
+
+    assert mqtt_payloads(mocked_hass, "safety_component/status")[-1] == "offline"
+
+
+def test_invalid_user_config_type_stops_cleanly(
+    mocked_hass_app_with_temp_component,
+):
+    app_instance, _, __, ___, _ = mocked_hass_app_with_temp_component
+    app_instance.args = {"app_config": {}, "user_config": None}
+
+    app_instance.initialize()
+
+    app_instance.log.assert_called_with(
+        "Invalid MQTT configuration: user_config must be a mapping",
+        level="ERROR",
+    )
+    assert app_instance._stopped == app_instance.name
 
 def test_common_entities_lookup(mocked_hass_app_with_temp_component):
     """Test that common entities are properly initialized and accessible."""
@@ -153,5 +206,6 @@ def test_initialize_no_faults_or_safety_components(mocked_hass_app_with_temp_com
     # Check if the warning log was called
     app_instance.log.assert_called_with("No faults or safety components defined. Stopping the app.", level="WARNING")
 
-    # Check if the app state was set to 'invalid_cfg'
-    mocked_hass.set_state.assert_called_with("sensor.safety_app_health", state="invalid_cfg")
+    # Check if the app state was published as 'invalid_cfg'
+    health_topic = mqtt_topic_for("sensor.safety_app_health")
+    assert mqtt_payloads(mocked_hass, health_topic)[-1] == "invalid_cfg"

--- a/backend/tests/test_safetyFunctions.py
+++ b/backend/tests/test_safetyFunctions.py
@@ -191,7 +191,7 @@ def test_initialize_no_faults_or_safety_components(mocked_hass_app_with_temp_com
 
     Scenario:
         - The configuration does not include any faults or safety components.
-        - Expected Result: The app stops, logging an appropriate warning, setting the app state to 'invalid_cfg', and calling terminate.
+        - Expected Result: The validator reports the error while MQTT health remains observable.
     """
     app_instance, mocked_hass, _, _, _ = mocked_hass_app_with_temp_component
 
@@ -199,13 +199,14 @@ def test_initialize_no_faults_or_safety_components(mocked_hass_app_with_temp_com
     app_instance.args['app_config']['faults'] = {}  # No faults defined
     app_instance.args['user_config']['safety_components'] = {}  # No safety components defined
 
-    mocked_hass.stop_app = Mock()
-    # Call initialize to test behavior
     app_instance.initialize()
 
-    # Check if the warning log was called
-    app_instance.log.assert_called_with("No faults or safety components defined. Stopping the app.", level="WARNING")
+    app_instance.log.assert_called_with(
+        "Invalid app configuration: app_config.faults must define at least one fault",
+        level="ERROR",
+    )
 
-    # Check if the app state was published as 'invalid_cfg'
     health_topic = mqtt_topic_for("sensor.safety_app_health")
     assert mqtt_payloads(mocked_hass, health_topic)[-1] == "invalid_cfg"
+    assert mqtt_payloads(mocked_hass, "safety_component/status")[-1] == "online"
+    assert not hasattr(app_instance, "_stopped")

--- a/backend/tests/test_safety_component_core.py
+++ b/backend/tests/test_safety_component_core.py
@@ -32,7 +32,7 @@ def _make_component():
     hass_app.log = Mock()
     common_entities = CommonEntities(hass_app, {"outside_temp": "sensor.outside"})
     event_bus = EventBus()
-    return DummyComponent(hass_app, common_entities, event_bus)
+    return DummyComponent(hass_app, common_entities, event_bus, Mock())
 
 
 def test_register_safety_component_errors_on_unknown_name():

--- a/backend/tests/test_system_notification_recovery.py
+++ b/backend/tests/test_system_notification_recovery.py
@@ -1,0 +1,196 @@
+"""System-level tests for notification and recovery manager integration."""
+
+import copy
+from typing import Any
+from unittest.mock import MagicMock
+
+from components.core.types_common import FaultState, RecoveryActionState
+
+from .fixtures.hass_fixture import MockBehavior, mock_get_state, update_mocked_get_state
+
+
+class _StatefulHassState:
+    """Small state store that makes set_state writes visible to get_state reads."""
+
+    def __init__(self, mock_behaviors: list[MockBehavior]) -> None:
+        self.entities: dict[str, dict[str, Any]] = {}
+        self.mock_behaviors = mock_behaviors
+
+    def set_state(
+        self,
+        entity_id: str,
+        state: Any = None,
+        attributes: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> None:
+        entity_state = self.entities.setdefault(
+            entity_id, {"state": None, "attributes": {}}
+        )
+        entity_state["state"] = state
+        if attributes is not None:
+            entity_state["attributes"] = attributes
+
+    def get_state(self, entity_id: str, **kwargs: Any) -> Any:
+        attribute = kwargs.get("attribute")
+        stored_state = self.entities.get(entity_id)
+
+        if attribute == "all":
+            if stored_state is None:
+                sensor_value = mock_get_state(entity_id, self.mock_behaviors)
+                if sensor_value is None:
+                    return None
+                return {"state": sensor_value, "attributes": {}}
+            return {
+                "state": stored_state["state"],
+                "attributes": stored_state.get("attributes", {}),
+            }
+
+        if stored_state is not None:
+            if attribute:
+                return stored_state.get("attributes", {}).get(attribute)
+            return stored_state["state"]
+
+        return mock_get_state(entity_id, self.mock_behaviors)
+
+
+def _install_stateful_hass(app_instance: Any, mock_behaviors: list[MockBehavior]) -> _StatefulHassState:
+    state_store = _StatefulHassState(mock_behaviors)
+    app_instance.get_state = MagicMock(side_effect=state_store.get_state)
+    app_instance.set_state = MagicMock(side_effect=state_store.set_state)
+    return state_store
+
+
+def _notify_calls(app_instance: Any) -> list[Any]:
+    return [
+        call
+        for call in app_instance.call_service.call_args_list
+        if call.args and call.args[0] == "notify/notify"
+    ]
+
+
+def test_notification_updates_single_fault_notification_for_prefault_lifecycle(
+    mocked_hass_app_with_temp_component,
+):
+    """
+    Verify the end-to-end notification lifecycle for one fault with multiple prefaults.
+
+    A second prefault for the same fault should update the existing notification
+    description, and the notification should only switch to cleared after the last
+    contributing prefault is cleared.
+    """
+    app_instance, _, __, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+    app_instance.args = copy.deepcopy(app_instance.args)
+    state_store = _install_stateful_hass(app_instance, mock_behaviors_default)
+
+    app_instance.initialize()
+    app_instance.call_service.reset_mock()
+    app_instance.set_state.reset_mock()
+
+    app_instance.fm.set_symptom("RiskyTemperatureOffice", {"location": "Office"})
+
+    notify_calls = _notify_calls(app_instance)
+    assert len(app_instance.notify_man.active_notification) == 1
+    fault_tag = next(iter(app_instance.notify_man.active_notification))
+    assert notify_calls[-1].kwargs["title"] == "Hazard!"
+    assert (
+        notify_calls[-1].kwargs["message"]
+        == "Fault: RiskyTemperature\nlocation: Office\n"
+    )
+    assert notify_calls[-1].kwargs["data"]["tag"] == fault_tag
+
+    app_instance.fm.set_symptom("RiskyTemperatureKitchen", {"location": "Kitchen"})
+
+    notify_calls = _notify_calls(app_instance)
+    assert list(app_instance.notify_man.active_notification) == [fault_tag]
+    assert (
+        notify_calls[-1].kwargs["message"]
+        == "Fault: RiskyTemperature\nlocation: Office, Kitchen\n"
+    )
+    assert notify_calls[-1].kwargs["data"]["tag"] == fault_tag
+    assert (
+        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        == "Office, Kitchen"
+    )
+
+    app_instance.fm.clear_symptom("RiskyTemperatureOffice", {"location": "Office"})
+
+    notify_calls = _notify_calls(app_instance)
+    assert app_instance.fm.check_fault("RiskyTemperature") == FaultState.SET
+    assert list(app_instance.notify_man.active_notification) == [fault_tag]
+    assert (
+        notify_calls[-1].kwargs["message"]
+        == "Fault: RiskyTemperature\nlocation: Kitchen\n"
+    )
+    assert (
+        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        == "Kitchen"
+    )
+
+    app_instance.fm.clear_symptom("RiskyTemperatureKitchen", {"location": "Kitchen"})
+
+    notify_calls = _notify_calls(app_instance)
+    assert app_instance.fm.check_fault("RiskyTemperature") == FaultState.CLEARED
+    assert app_instance.notify_man.active_notification == {}
+    assert notify_calls[-1].kwargs["message"].endswith(" has been cleared.")
+    assert notify_calls[-1].kwargs["data"]["tag"] == fault_tag
+    assert state_store.entities["sensor.fault_RiskyTemperature"]["state"] == "Cleared"
+    assert (
+        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        == ""
+    )
+
+
+def test_recovery_manager_sets_recovery_state_and_actuator_entities(
+    mocked_hass_app_with_temp_component,
+):
+    """
+    Verify that recovery evaluates the temperature context and writes recovery entities.
+
+    With outside temperature lower than the room temperature, the recovery action should
+    request the configured window actuator to close and mark the recovery as pending.
+    """
+    app_instance, _, __, ___, mock_behaviors_default = (
+        mocked_hass_app_with_temp_component
+    )
+    app_instance.args = copy.deepcopy(app_instance.args)
+    office_cfg = app_instance.args["user_config"]["safety_components"][
+        "TemperatureComponent"
+    ]["rooms"]["Office"]
+    office_cfg["actuator"] = "cover.office_window"
+
+    mock_behaviors = update_mocked_get_state(
+        mock_behaviors_default,
+        [
+            MockBehavior("sensor.office_temperature", iter(["5"])),
+            MockBehavior("sensor.dom_temperature", iter(["1"])),
+        ],
+    )
+    _install_stateful_hass(app_instance, mock_behaviors)
+
+    app_instance.initialize()
+    app_instance.reco_man._is_dry_test_failed = MagicMock(return_value=False)
+    app_instance.reco_man._isRecoveryConflict = MagicMock(return_value=False)
+    app_instance.set_state.reset_mock()
+    app_instance.listen_state.reset_mock()
+
+    app_instance.fm.set_symptom("RiskyTemperatureOffice", {"location": "Office"})
+
+    symptom = app_instance.symptoms["RiskyTemperatureOffice"]
+    recovery_action = app_instance.reco_man.recovery_actions["RiskyTemperatureOffice"]
+    assert recovery_action.current_status == RecoveryActionState.TO_PERFORM
+    app_instance.set_state.assert_any_call(
+        "sensor.recovery_manipulatewindowoffice", state="TO_PERFORM"
+    )
+    app_instance.set_state.assert_any_call("cover.office_window", state="off")
+    app_instance.listen_state.assert_any_call(
+        app_instance.reco_man._recovery_performed,
+        "sensor.office_window_contact_contact",
+        symptom=symptom,
+    )
+    app_instance.listen_state.assert_any_call(
+        app_instance.reco_man._recovery_performed,
+        "cover.office_window",
+        symptom=symptom,
+    )

--- a/backend/tests/test_system_notification_recovery.py
+++ b/backend/tests/test_system_notification_recovery.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock
 
 from components.core.types_common import FaultState, RecoveryActionState
 
-from .fixtures.hass_fixture import MockBehavior, mock_get_state, update_mocked_get_state
+from .fixtures.hass_fixture import (
+    MockBehavior,
+    mock_get_state,
+    mqtt_payloads,
+    mqtt_topic_for,
+    update_mocked_get_state,
+)
 
 
 class _StatefulHassState:
@@ -110,7 +116,9 @@ def test_notification_updates_single_fault_notification_for_prefault_lifecycle(
     )
     assert notify_calls[-1].kwargs["data"]["tag"] == fault_tag
     assert (
-        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        app_instance.mqtt_entities.get_attributes("sensor.fault_RiskyTemperature")[
+            "location"
+        ]
         == "Office, Kitchen"
     )
 
@@ -124,7 +132,9 @@ def test_notification_updates_single_fault_notification_for_prefault_lifecycle(
         == "Fault: RiskyTemperature\nlocation: Kitchen\n"
     )
     assert (
-        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        app_instance.mqtt_entities.get_attributes("sensor.fault_RiskyTemperature")[
+            "location"
+        ]
         == "Kitchen"
     )
 
@@ -135,9 +145,17 @@ def test_notification_updates_single_fault_notification_for_prefault_lifecycle(
     assert app_instance.notify_man.active_notification == {}
     assert notify_calls[-1].kwargs["message"].endswith(" has been cleared.")
     assert notify_calls[-1].kwargs["data"]["tag"] == fault_tag
-    assert state_store.entities["sensor.fault_RiskyTemperature"]["state"] == "Cleared"
     assert (
-        state_store.entities["sensor.fault_RiskyTemperature"]["attributes"]["location"]
+        mqtt_payloads(
+            app_instance,
+            mqtt_topic_for("sensor.fault_RiskyTemperature"),
+        )[-1]
+        == "Cleared"
+    )
+    assert (
+        app_instance.mqtt_entities.get_attributes("sensor.fault_RiskyTemperature")[
+            "location"
+        ]
         == ""
     )
 
@@ -165,6 +183,10 @@ def test_recovery_manager_sets_recovery_state_and_actuator_entities(
         [
             MockBehavior("sensor.office_temperature", iter(["5"])),
             MockBehavior("sensor.dom_temperature", iter(["1"])),
+            MockBehavior(
+                "sensor.office_window_contact_contact",
+                iter(["on", "on", "on"]),
+            ),
         ],
     )
     _install_stateful_hass(app_instance, mock_behaviors)
@@ -172,7 +194,7 @@ def test_recovery_manager_sets_recovery_state_and_actuator_entities(
     app_instance.initialize()
     app_instance.reco_man._is_dry_test_failed = MagicMock(return_value=False)
     app_instance.reco_man._isRecoveryConflict = MagicMock(return_value=False)
-    app_instance.set_state.reset_mock()
+    app_instance.call_service.reset_mock()
     app_instance.listen_state.reset_mock()
 
     app_instance.fm.set_symptom("RiskyTemperatureOffice", {"location": "Office"})
@@ -180,17 +202,25 @@ def test_recovery_manager_sets_recovery_state_and_actuator_entities(
     symptom = app_instance.symptoms["RiskyTemperatureOffice"]
     recovery_action = app_instance.reco_man.recovery_actions["RiskyTemperatureOffice"]
     assert recovery_action.current_status == RecoveryActionState.TO_PERFORM
-    app_instance.set_state.assert_any_call(
-        "sensor.recovery_manipulatewindowoffice", state="TO_PERFORM"
+    assert (
+        mqtt_payloads(
+            app_instance,
+            mqtt_topic_for("sensor.recovery_ManipulateWindowOffice"),
+        )[-1]
+        == "TO_PERFORM"
     )
-    app_instance.set_state.assert_any_call("cover.office_window", state="off")
+    app_instance.call_service.assert_any_call(
+        "cover/close_cover", entity_id="cover.office_window"
+    )
+    assert not mqtt_payloads(
+        app_instance,
+        "safety_component/command/cover_office_window/set",
+    )
     app_instance.listen_state.assert_any_call(
         app_instance.reco_man._recovery_performed,
         "sensor.office_window_contact_contact",
+        new="off",
         symptom=symptom,
-    )
-    app_instance.listen_state.assert_any_call(
-        app_instance.reco_man._recovery_performed,
-        "cover.office_window",
-        symptom=symptom,
+        confirmation_entity="sensor.office_window_contact_contact",
+        expected_state="off",
     )

--- a/docs/sys/SafetyComponent - SSRD.md
+++ b/docs/sys/SafetyComponent - SSRD.md
@@ -108,13 +108,14 @@ This Software Safety Requirements Document (SSRD) captures the current state of 
 
 ### 4.1 Logical Components
 
-- **SafetyFunctions (AppDaemon app)**: Orchestrator; loads config; instantiates components; wires FM/NM/RM; sets health entity.
+- **SafetyFunctions (AppDaemon app)**: Orchestrator; loads config; instantiates components; wires FM/NM/RM; publishes MQTT-discovered health and status entities.
 - **SafetyComponent (abstract base)**: Provides SM lifecycle, debouncing, FM integration, decorator for enable/disable & retries.
 - **TemperatureComponent (MVP)**: Implements under-temperature & forecast SMs.
 - **FaultManager**: Owns Symptom/Fault models, aggregates, manages lifecycle.
 - **NotificationManager**: Maps fault lifecycle to HA notify service.
 - **RecoveryManager**: Orchestrates recovery actions, resolves conflicts.
 - **DerivativeMonitor**: Singleton calculating derivatives, publishing `_rate` entities.
+- **MqttEntityManager**: Owns MQTT discovery, internal entity state publishing, JSON attributes, retained cleanup, availability, and heartbeat refresh.
 - **CommonEntities**: Accessor for shared HA entities.
 
 ### 4.2 Data Flow Summary
@@ -123,13 +124,15 @@ This Software Safety Requirements Document (SSRD) captures the current state of 
 2. Components register SMs; decorator handles debounce + FM.
 3. HA triggers SM; SafetyComponent → FM.
 4. FM updates Fault state → NM + RM.
-5. RM executes recovery actions; NM sends notifications.
-6. DerivativeMonitor runs periodically; outputs consumed by TC forecast SM.
+5. RM invokes an allow-listed native HA service and waits for the configured postcondition; NM sends notifications.
+6. DerivativeMonitor runs periodically; publishes MQTT `_rate` sensor states consumed by TC forecast SM.
+
+Internal SafetyFunctions entities are exposed through MQTT discovery and are updated through MQTT state and JSON attributes topics, not through AppDaemon `set_state`.
 
 ### 4.3 Deployment
 
 - Runs in HA/AppDaemon container.
-- Interfaces: `set_state`, `listen_state`, `run_in`, `run_every`, `call_service`.
+- Interfaces: MQTT discovery/state/attribute/availability publishing via `call_service("mqtt/publish")`; allow-listed actuator services through `call_service`; plus `listen_state`, `run_in`, and `run_every` for external HA inputs, recovery confirmation, and scheduling.
 - Debugging: `remote_pdb` when enabled.
 
 ---

--- a/frontend/.d.ts
+++ b/frontend/.d.ts
@@ -17,6 +17,7 @@ interface ImportMeta {
 // For Node's process.env
 declare global {
   namespace NodeJS {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     interface ProcessEnv extends CustomEnv {}
   }
 }

--- a/frontend/scripts/deploy.ts
+++ b/frontend/scripts/deploy.ts
@@ -21,7 +21,7 @@ async function checkDirectoryExists() {
   try {
     await access(LOCAL_DIRECTORY, constants.F_OK);
     return true;
-  } catch (err) {
+  } catch {
     return false;
   }
 }

--- a/frontend/src/components/ActionsList.tsx
+++ b/frontend/src/components/ActionsList.tsx
@@ -46,29 +46,19 @@ const ActionCard: React.FC<{ action: Action }> = ({ action }) => (
   </div>
 );
 
-interface BackendRecoveryAction {
-  name?: string;
-  params?: Record<string, unknown>;
-  status?: string;
-}
-
 const ActionsList: React.FC = () => {
   const { getAllEntities } = useHass();
   const entities = getAllEntities();
 
-  const appHealthEntity = entities['sensor.safety_app_health'];
-  const recoveryActions = appHealthEntity?.attributes?.recovery_actions as Record<string, BackendRecoveryAction> | undefined;
-  const actions: Action[] = Object.entries(recoveryActions || {}).map(([id, action]) => {
-    const description = Object.entries(action.params || {})
-      .map(([key, value]) => `${key}: ${String(value)}`)
-      .join(', ');
-    return {
-      id,
-      title: action.name || id,
-      description: description || 'No parameters',
-      status: action.status === 'TO_PERFORM' ? 'in-progress' : 'pending',
-    };
-  });
+  const actions: Action[] = Object.entries(entities)
+    .filter(([entityId]) => entityId.startsWith('sensor.recovery_'))
+    .map<Action>(([entityId, entity]) => ({
+      id: entityId,
+      title: String(entity.attributes.friendly_name || '') || entityId.replace('sensor.recovery_', '').replace(/_/g, ' '),
+      description: String(entity.attributes.description || '') || `MQTT entity: ${entityId}`,
+      status: entity.state === 'TO_PERFORM' ? 'in-progress' : 'pending',
+    }))
+    .sort((left, right) => left.title.localeCompare(right.title));
 
   return (
     <div style={{ padding: '20px', backgroundColor: '#1e293b', borderRadius: '8px' }}>

--- a/frontend/src/components/ActionsList.tsx
+++ b/frontend/src/components/ActionsList.tsx
@@ -8,10 +8,10 @@ interface Action {
   status: 'pending' | 'in-progress' | 'completed';
 }
 
-const statusColors: Record<Action['status'], string> = {
-  pending: 'background-color: #7c2d12; color: #fde68a;',
-  'in-progress': 'background-color: #1e3a8a; color: #bfdbfe;',
-  completed: 'background-color: #065f46; color: #d1fae5;',
+const statusStyles: Record<Action['status'], React.CSSProperties> = {
+  pending: { backgroundColor: '#7c2d12', color: '#fde68a' },
+  'in-progress': { backgroundColor: '#1e3a8a', color: '#bfdbfe' },
+  completed: { backgroundColor: '#065f46', color: '#d1fae5' },
 };
 
 const ActionCard: React.FC<{ action: Action }> = ({ action }) => (
@@ -27,9 +27,7 @@ const ActionCard: React.FC<{ action: Action }> = ({ action }) => (
   >
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
       <div>
-        <h3 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 'bold', color: '#f3f4f6' }}>
-          {action.title}
-        </h3>
+        <h3 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 'bold', color: '#f3f4f6' }}>{action.title}</h3>
         <p style={{ margin: '5px 0 0', color: '#9ca3af' }}>{action.description}</p>
       </div>
       <span
@@ -39,7 +37,7 @@ const ActionCard: React.FC<{ action: Action }> = ({ action }) => (
           fontSize: '0.875rem',
           fontWeight: 'bold',
           whiteSpace: 'nowrap',
-          ...parseStatusStyle(statusColors[action.status]),
+          ...statusStyles[action.status],
         }}
       >
         {action.status}
@@ -48,23 +46,29 @@ const ActionCard: React.FC<{ action: Action }> = ({ action }) => (
   </div>
 );
 
-function parseStatusStyle(style: string) {
-  const styleObj: React.CSSProperties = {};
-  style.split(';').forEach(rule => {
-    const [key, value] = rule.split(':').map(s => s.trim());
-    if (key && value) {
-      styleObj[key as keyof React.CSSProperties] = value;
-    }
-  });
-  return styleObj;
+interface BackendRecoveryAction {
+  name?: string;
+  params?: Record<string, unknown>;
+  status?: string;
 }
 
 const ActionsList: React.FC = () => {
   const { getAllEntities } = useHass();
   const entities = getAllEntities();
 
-  const appHealthEntity = entities['app_health'];
-  const actions: Action[] = appHealthEntity?.recoveryActions || [];
+  const appHealthEntity = entities['sensor.safety_app_health'];
+  const recoveryActions = appHealthEntity?.attributes?.recovery_actions as Record<string, BackendRecoveryAction> | undefined;
+  const actions: Action[] = Object.entries(recoveryActions || {}).map(([id, action]) => {
+    const description = Object.entries(action.params || {})
+      .map(([key, value]) => `${key}: ${String(value)}`)
+      .join(', ');
+    return {
+      id,
+      title: action.name || id,
+      description: description || 'No parameters',
+      status: action.status === 'TO_PERFORM' ? 'in-progress' : 'pending',
+    };
+  });
 
   return (
     <div style={{ padding: '20px', backgroundColor: '#1e293b', borderRadius: '8px' }}>

--- a/frontend/src/components/FaultSection.tsx
+++ b/frontend/src/components/FaultSection.tsx
@@ -1,21 +1,35 @@
 import React, { useState } from 'react';
-import { useEntity } from '@hakit/core';
+import { useEntity, useHass } from '@hakit/core';
+
+interface EntitySnapshot {
+  state?: string;
+  attributes?: Record<string, unknown>;
+}
+
+interface HealthConfiguration {
+  faults?: Record<string, unknown>;
+}
 
 const FaultSection: React.FC = () => {
   const [openLevels, setOpenLevels] = useState<string[]>([]); // Track multiple opened levels
   const healthEntity = useEntity('sensor.safety_app_health');
-  const faultsConfig = healthEntity?.attributes?.configuration?.faults || {};
+  const { getAllEntities } = useHass();
+  const entities = getAllEntities() as unknown as Record<string, EntitySnapshot>;
+  const configuration = healthEntity.attributes?.configuration as HealthConfiguration | undefined;
+  const faultsConfig = configuration?.faults || {};
 
   const faultEntities = Object.keys(faultsConfig).map(faultKey => `sensor.fault_${faultKey.toLowerCase()}`);
 
   const faultData = faultEntities.map(entityId => {
+    const entity = entities[entityId];
+    const attributes = entity?.attributes || {};
     return {
       id: entityId,
-      state: (useEntity(entityId) || {}).state || 'Unknown',
-      friendlyName: ((useEntity(entityId) || {}).attributes || {}).friendly_name || entityId.replace('sensor.fault_', ''),
-      description: ((useEntity(entityId) || {}).attributes || {}).description || '',
-      location: ((useEntity(entityId) || {}).attributes || {}).location || '',
-      level: ((useEntity(entityId) || {}).attributes || {}).level || 'level_4',
+      state: entity?.state || 'Unknown',
+      friendlyName: String(attributes.friendly_name || entityId.replace('sensor.fault_', '')),
+      description: String(attributes.description || ''),
+      location: String(attributes.location || ''),
+      level: String(attributes.level || 'level_4'),
     };
   });
 

--- a/frontend/src/components/LogList.tsx
+++ b/frontend/src/components/LogList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface Log {
+export interface Log {
   timestamp: string;
   type: 'info' | 'warning' | 'error';
   message: string;

--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -1,8 +1,8 @@
 import { useEntity } from '@hakit/core';
 
 export default function Topbar() {
-  const safetyState = useEntity('sensor.safetysystem_state');
-  const healthState = useEntity('sensor.safety_app_health');
+  const safetyEntity = useEntity('sensor.safetysystem_state');
+  const healthEntity = useEntity('sensor.safety_app_health');
 
   // Configuration for Safety Status
   const statusConfig = {
@@ -46,17 +46,41 @@ export default function Topbar() {
       textColor: 'text-white',
       animation: '', // No animation
     },
+    init: {
+      label: 'System Starting',
+      bgColor: 'from-yellow-400 to-yellow-600',
+      textColor: 'text-black',
+      animation: 'animate-pulse',
+    },
+    invalid_cfg: {
+      label: 'Invalid Configuration',
+      bgColor: 'from-red-500 to-red-700',
+      textColor: 'text-white',
+      animation: 'animate-pulse',
+    },
     stopped: {
       label: 'System Stopped',
       bgColor: 'from-red-500 to-red-700',
       textColor: 'text-white',
       animation: 'animate-pulse', // Pulsating animation for stopped state
     },
+    unavailable: {
+      label: 'System Unavailable',
+      bgColor: 'from-red-500 to-red-700',
+      textColor: 'text-white',
+      animation: 'animate-pulse',
+    },
   };
 
   // Current configurations
-  const currentStatus = statusConfig[safetyState] || statusConfig.cleared;
-  const currentHealth = healthConfig[healthState] || healthConfig.running;
+  const safetyState =
+    safetyEntity.state === 'safe' || safetyEntity.state === '0'
+      ? 'cleared'
+      : safetyEntity.state.startsWith('level_')
+        ? safetyEntity.state
+        : `level_${safetyEntity.state}`;
+  const currentStatus = statusConfig[safetyState as keyof typeof statusConfig] || statusConfig.cleared;
+  const currentHealth = healthConfig[healthEntity.state as keyof typeof healthConfig] || healthConfig.unavailable;
 
   return (
     <div

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-import { Column } from '@hakit/components';
 import FaultSection from '../components/FaultSection'; // FaultSection component
 import ActionsList from '../components/ActionsList'; // ActionsList component
-import LogList from '../components/LogList'; // Reusable LogList component
+import LogList, { type Log } from '../components/LogList'; // Reusable LogList component
 
 // Sample logs
-const logs = [
+const logs: Log[] = [
   {
     timestamp: '2025-01-14T12:00:00Z',
     type: 'info',

--- a/frontend/src/pages/LogPage.tsx
+++ b/frontend/src/pages/LogPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import LogList from '../components/LogList'; // Reusable LogList component
+import LogList, { type Log } from '../components/LogList'; // Reusable LogList component
 
 // Sample logs
-const logs = [
+const logs: Log[] = [
   {
     timestamp: '2025-01-14T12:00:00Z',
     type: 'info',


### PR DESCRIPTION
## Summary

- replace AppDaemon-created internal states with MQTT discovery entities managed by a dedicated `MqttEntityManager`
- publish health, system, fault, recovery, and temperature-derivative sensors with stable entity IDs, availability, expiry, heartbeat refresh, and retained-discovery cleanup
- keep physical recovery actions on constrained native Home Assistant services and harden multi-entity recovery confirmation
- migrate configuration validation, tests, documentation, and frontend consumers to the MQTT entity contract

## Why

The previous `set_state`-based outputs were ephemeral AppDaemon states rather than durable Home Assistant entities. This caused stale or suffixed entity IDs, weak availability semantics, and inconsistent consumers after restarts or deployments. The migration gives these outputs an explicit MQTT lifecycle and one stable public contract.

## Impact

Home Assistant now discovers exactly 28 Safety Component sensors under the expected IDs. State payloads are non-retained, discovery and availability are retained, and `expire_after` is refreshed by a 60-second heartbeat. Recovery actuator commands remain native HA service calls; no MQTT command topics or direct state-forcing are introduced.

The `home-safety` dashboard on the deployed instance was also migrated from stale office/recovery IDs to the new entity IDs.

## Validation

- `pytest backend/tests -q` — 164 passed
- `npx tsc -p tsconfig.app.json --noEmit --pretty false` — passed
- `npm run lint -- --max-warnings=0` — passed
- `npx vite build` — passed (592 modules)
- `git diff --check` — passed
- deployed to the live AppDaemon instance and verified:
  - all 28 MQTT entities registered under exact IDs, without collision suffixes
  - `sensor.safety_app_health` remains `running`
  - system state is nominal (`0`), faults are `Cleared`, recovery states are `DO_NOT_PERFORM`
  - first and second temperature derivatives progressed from initialization to numeric values on their scheduled sampling cycles
  - AppDaemon remained started with no SafetyFunctions traceback or callback/configuration errors

No physical recovery action was triggered during live verification.